### PR TITLE
Add macOS desktop packaging workflow

### DIFF
--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -3,6 +3,15 @@ name: Build macOS DMG
 on:
   workflow_dispatch:
   push:
+    branches:
+      - packaging
+    paths:
+      - ".github/workflows/package-macos.yml"
+      - "build_tools/**"
+      - "GONet_Wizard/**"
+      - "pyproject.toml"
+      - ".gitignore"
+      - "tests/**"
     tags:
       - "v*"
 

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -1,0 +1,64 @@
+name: Build macOS DMG
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  macos-dmg:
+    name: macOS unsigned DMG
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install package and build dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[build]"
+
+      - name: Build unsigned macOS DMG
+        run: |
+          build_tools/macos/build_dmg.sh --force-pyinstaller
+
+      - name: Create checksums
+        run: |
+          cd dist
+          shasum -a 256 *.dmg > SHA256SUMS-macOS.txt
+          cat SHA256SUMS-macOS.txt
+
+      - name: Upload short-lived build artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: gonet-wizard-macos-dmg
+          path: |
+            dist/*.dmg
+            dist/SHA256SUMS-macOS.txt
+          retention-days: 7
+
+      - name: Upload assets to tagged GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release view "${TAG_NAME}" >/dev/null 2>&1 || \
+            gh release create "${TAG_NAME}" \
+              --draft \
+              --title "GONet Wizard ${TAG_NAME}" \
+              --notes "Draft release created automatically from ${TAG_NAME}."
+          gh release upload "${TAG_NAME}" dist/*.dmg dist/SHA256SUMS-macOS.txt --clobber

--- a/.github/workflows/package-macos.yml
+++ b/.github/workflows/package-macos.yml
@@ -2,16 +2,19 @@ name: Build macOS DMG
 
 on:
   workflow_dispatch:
+    inputs:
+      version:
+        description: "Optional version label for the DMG, e.g. 0.3.0-test"
+        required: false
+        default: ""
+        type: string
+      force_pyinstaller:
+        description: "Force a fresh PyInstaller build before creating the DMG"
+        required: true
+        default: true
+        type: boolean
+
   push:
-    branches:
-      - packaging
-    paths:
-      - ".github/workflows/package-macos.yml"
-      - "build_tools/**"
-      - "GONet_Wizard/**"
-      - "pyproject.toml"
-      - ".gitignore"
-      - "tests/**"
     tags:
       - "v*"
 
@@ -41,8 +44,23 @@ jobs:
           python -m pip install -e ".[build]"
 
       - name: Build unsigned macOS DMG
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+          FORCE_PYINSTALLER: ${{ inputs.force_pyinstaller }}
         run: |
-          build_tools/macos/build_dmg.sh --force-pyinstaller
+          ARGS=()
+
+          if [[ "${FORCE_PYINSTALLER:-true}" == "true" ]]; then
+            ARGS+=(--force-pyinstaller)
+          else
+            ARGS+=(--skip-pyinstaller)
+          fi
+
+          if [[ -n "${REQUESTED_VERSION:-}" ]]; then
+            ARGS+=(--version "${REQUESTED_VERSION}")
+          fi
+
+          build_tools/macos/build_dmg.sh "${ARGS[@]}"
 
       - name: Create checksums
         run: |
@@ -70,4 +88,5 @@ jobs:
               --draft \
               --title "GONet Wizard ${TAG_NAME}" \
               --notes "Draft release created automatically from ${TAG_NAME}."
+
           gh release upload "${TAG_NAME}" dist/*.dmg dist/SHA256SUMS-macOS.txt --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+!build_tools/pyinstaller/*.spec
 
 # Installer logs
 pip-log.txt
@@ -168,3 +169,11 @@ data/**/*.json
 #Personal scripts and logging
 tag_and_push.sh
 commit_changelog.txt
+# Local editor settings
+.vscode/
+
+# Ignore build artifacts and installer files
+*.dmg
+*.exe
+*.msi
+*.pkg

--- a/GONet_Wizard/GONet_dashboard/src/server.py
+++ b/GONet_Wizard/GONet_dashboard/src/server.py
@@ -21,4 +21,4 @@ import GONet_Wizard.settings as settings
 server = Flask('GONet_dashboard')
 
 #: The Dash app instance.
-app = Dash(server=server, assets_folder=settings.STATIC)
+app = Dash(server=server, assets_folder=str(settings.STATIC))

--- a/GONet_Wizard/GONet_utils/src/data_spec.py
+++ b/GONet_Wizard/GONet_utils/src/data_spec.py
@@ -25,8 +25,9 @@ Classes
 """
 
 import yaml
-from pathlib import Path
 from typing import List, Dict, Any
+
+from GONet_Wizard.resources import data_file
 
 class Field:
     """
@@ -94,8 +95,8 @@ class Field:
         self.field_type = field_type  # 'env' or 'chn'
         self.load: Dict[str, Any] = extras.get("load", {}) or {}
 
-# Path to YAML file relative to this script
-DATA_SPEC_PATH = Path(__file__).parent / "data_spec.yaml"
+# Path to YAML file shipped with the package.
+DATA_SPEC_PATH = data_file("data_spec.yaml", must_exist=True)
 
 # Load and instantiate Field objects
 with open(DATA_SPEC_PATH, "r", encoding="utf-8") as f:

--- a/GONet_Wizard/GONet_utils/src/extract_app/extract_server.py
+++ b/GONet_Wizard/GONet_utils/src/extract_app/extract_server.py
@@ -33,20 +33,51 @@ app : :class:`dash_extensions.enrich.DashProxy`
 
 from flask import Flask
 from dash_extensions.enrich import DashProxy, ServersideOutputTransform
-from pathlib import Path
+
+try:
+    from dash_extensions.enrich import FileSystemBackend
+except ImportError:  # pragma: no cover - compatibility with older dash-extensions
+    try:
+        from dash_extensions.enrich import FileSystemStore as FileSystemBackend
+    except ImportError:  # pragma: no cover
+        FileSystemBackend = None
+
 import shutil, atexit, signal, os
 
 import GONet_Wizard.settings as settings
 from GONet_Wizard.logging_utils import get_logger
+from GONet_Wizard.paths import cache_dir
 
 logger = get_logger(__name__)
 
-# Default FS backend folder used by dash-extensions when no backend is provided
-# (created in the current working directory). We’ll clean it proactively.
-CACHE_DIRS = [
-    Path(__file__).resolve().parent / "file_system_backend",  # common case
-    Path.cwd() / "file_system_backend",                       # safety if CWD differs
-]
+# Default filesystem backend folder used by dash-extensions when no backend
+# is provided. Store it under the user cache directory instead of the package
+# directory so frozen/installed applications never write into their install tree.
+CACHE_DIR = cache_dir("dash", "extract_gui", "file_system_backend")
+CACHE_DIRS = [CACHE_DIR]
+
+
+def _serverside_output_transform() -> ServersideOutputTransform:
+    """
+    Build a server-side output transform using a user-writable cache directory.
+
+    Returns
+    -------
+    dash_extensions.enrich.ServersideOutputTransform
+        Transform configured to store temporary server-side callback payloads
+        outside the package/install directory whenever the installed
+        dash-extensions version exposes a filesystem backend class.
+    """
+    if FileSystemBackend is None:
+        return ServersideOutputTransform()
+
+    backend = FileSystemBackend(cache_dir=str(CACHE_DIR))
+
+    try:
+        return ServersideOutputTransform(backends=[backend])
+    except TypeError:  # pragma: no cover - older dash-extensions API
+        return ServersideOutputTransform(backend=backend)
+
 
 def _clear_cache_dirs() -> None:
     """
@@ -72,8 +103,8 @@ server = Flask("GONet Wizard extraction GUI")
 app = DashProxy(
     __name__,
     server=server,
-    assets_folder=settings.STATIC,
-    transforms=[ServersideOutputTransform()],
+    assets_folder=str(settings.STATIC),
+    transforms=[_serverside_output_transform()],
 )
 
 app.index_string = """

--- a/GONet_Wizard/_branding.py
+++ b/GONet_Wizard/_branding.py
@@ -34,29 +34,38 @@ Notes
 
 from __future__ import annotations
 
-import sys, platform, webview
+import platform, sys, webview
 from pathlib import Path
+
+from GONet_Wizard.resources import logo_path, resource_path
 
 _ICON_SET = False  # process-wide guard
 
 
-def _resource_path(*rel_parts: str) -> str:
+def _resource_path(*parts: str) -> str:
     """
-    Build an absolute path to a resource shipped with the package.
+    Return a package resource path using the legacy branding helper contract.
+
+    This compatibility wrapper preserves the historical behavior used by the
+    branding tests: when PyInstaller exposes ``sys._MEIPASS``, paths are
+    resolved directly below that directory. New production code should prefer
+    :func:`GONet_Wizard.resources.resource_path` and the more specific helpers
+    in :mod:`GONet_Wizard.resources`.
 
     Parameters
     ----------
-    rel_parts : :class:`str`
-        One or more path segments relative to this file's directory (or the
-        PyInstaller `_MEIPASS` temp directory if present).
+    *parts : str
+        Resource path segments to append to the package or bundle root.
 
     Returns
     -------
-    :class:`str`
+    str
         Absolute filesystem path to the requested resource.
     """
-    base = Path(getattr(sys, "_MEIPASS", Path(__file__).resolve().parent))
-    return str(base.joinpath(*rel_parts))
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass is not None:
+        return str(Path(meipass).joinpath(*parts))
+    return str(resource_path(*parts))
 
 
 def _default_icon_path() -> str:
@@ -76,9 +85,8 @@ def _default_icon_path() -> str:
         Absolute filesystem path to the icon file.
     """
     if platform.system() == "Darwin":
-        return _resource_path("static", "img", "logo", "GONet_Wizard.icns")
-    else:
-        return _resource_path("static", "img", "logo", "GONet_Wizard.ico")
+        return str(logo_path("GONet_Wizard.icns"))
+    return str(logo_path("GONet_Wizard.ico"))
 
 
 def set_dock_icon_once(path: str | None = None) -> None:

--- a/GONet_Wizard/desktop.py
+++ b/GONet_Wizard/desktop.py
@@ -1,0 +1,49 @@
+# GONet_Wizard/desktop.py
+
+"""
+Desktop GUI Entrypoint
+======================
+
+This module provides a GUI-first entry point for packaged desktop builds.  It is
+intended for ``[project.gui-scripts]`` and frozen application launchers where the
+user starts GONet Wizard by double-clicking an icon rather than typing a command
+in a terminal.
+
+The desktop entry point deliberately reuses the existing CLI command system by
+invoking the ``gui`` command programmatically.  This keeps the graphical launcher
+as a thin distribution layer and preserves all terminal functionality for power
+users.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Sequence
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    """
+    Launch the GONet Wizard GUI launcher.
+
+    Parameters
+    ----------
+    argv : sequence of str, optional
+        Optional arguments to pass after the implicit ``gui`` command.  When
+        ``None``, command-line arguments supplied to the GUI script are used.
+        For example, ``gonet-wizard-gui --port 5051`` becomes equivalent to
+        ``gonet-wizard gui --port 5051``.
+
+    Returns
+    -------
+    None
+        The function starts the normal GONet Wizard GUI workflow for its side
+        effects.
+    """
+    from GONet_Wizard.cli import main as cli_main
+
+    extra_args = list(sys.argv[1:] if argv is None else argv)
+    cli_main(["gui", *extra_args])
+
+
+if __name__ == "__main__":
+    main()

--- a/GONet_Wizard/paths.py
+++ b/GONet_Wizard/paths.py
@@ -1,0 +1,190 @@
+# GONet_Wizard/paths.py
+
+"""
+User-Writable Path Helpers
+==========================
+
+Installed desktop applications should treat their installation directory as
+read-only.  This module provides small platform-aware helpers for paths that the
+application may write to at runtime: cache files, logs, configuration files, and
+user data.
+
+The helpers avoid third-party dependencies so they can be used very early during
+application startup and inside frozen bundles.  Tests and advanced users can set
+``GONET_WIZARD_HOME`` to force all writable paths under a single directory.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+from pathlib import Path
+from typing import Literal
+
+
+APP_NAME = "GONet Wizard"
+APP_SLUG = "gonet-wizard"
+ENV_HOME = "GONET_WIZARD_HOME"
+PathKind = Literal["data", "config", "cache", "logs", "temp"]
+
+
+def _ensure(path: Path, *, create: bool) -> Path:
+    """
+    Optionally create a directory and return it.
+
+    Parameters
+    ----------
+    path : pathlib.Path
+        Directory path to return.
+    create : bool
+        If ``True``, create the directory and parents when missing.
+
+    Returns
+    -------
+    pathlib.Path
+        The original path.
+    """
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _home_override(kind: PathKind) -> Path | None:
+    """
+    Return an override directory from ``GONET_WIZARD_HOME`` if configured.
+
+    Parameters
+    ----------
+    kind : {"data", "config", "cache", "logs", "temp"}
+        Writable path category.
+
+    Returns
+    -------
+    pathlib.Path or None
+        Override directory for the requested category, or ``None`` when the
+        environment variable is not configured.
+    """
+    raw = os.environ.get(ENV_HOME)
+    if not raw:
+        return None
+    base = Path(raw).expanduser()
+    return base / kind
+
+
+def _platform_base(kind: PathKind) -> Path:
+    """
+    Return the platform-specific base directory for one path category.
+
+    Parameters
+    ----------
+    kind : {"data", "config", "cache", "logs", "temp"}
+        Writable path category.
+
+    Returns
+    -------
+    pathlib.Path
+        Platform-appropriate base directory for GONet Wizard runtime files.
+    """
+    system = platform.system()
+    home = Path.home()
+
+    if system == "Darwin":
+        if kind == "cache":
+            return home / "Library" / "Caches" / APP_NAME
+        if kind == "logs":
+            return home / "Library" / "Logs" / APP_NAME
+        if kind == "temp":
+            return home / "Library" / "Caches" / APP_NAME / "TemporaryItems"
+        return home / "Library" / "Application Support" / APP_NAME
+
+    if system == "Windows":
+        roaming = Path(os.environ.get("APPDATA", home / "AppData" / "Roaming"))
+        local = Path(os.environ.get("LOCALAPPDATA", home / "AppData" / "Local"))
+        if kind in {"cache", "logs", "temp"}:
+            suffix = {
+                "cache": "Cache",
+                "logs": "Logs",
+                "temp": "Temp",
+            }[kind]
+            return local / APP_NAME / suffix
+        return roaming / APP_NAME
+
+    # Linux and other Unix-like systems follow XDG defaults where possible.
+    if kind == "cache":
+        return Path(os.environ.get("XDG_CACHE_HOME", home / ".cache")) / APP_SLUG
+    if kind == "config":
+        return Path(os.environ.get("XDG_CONFIG_HOME", home / ".config")) / APP_SLUG
+    if kind == "logs":
+        return Path(os.environ.get("XDG_STATE_HOME", home / ".local" / "state")) / APP_SLUG / "logs"
+    if kind == "temp":
+        return Path(os.environ.get("XDG_CACHE_HOME", home / ".cache")) / APP_SLUG / "tmp"
+    return Path(os.environ.get("XDG_DATA_HOME", home / ".local" / "share")) / APP_SLUG
+
+
+def user_dir(kind: PathKind, *parts: str | Path, create: bool = True) -> Path:
+    """
+    Return a user-writable application directory.
+
+    Parameters
+    ----------
+    kind : {"data", "config", "cache", "logs", "temp"}
+        Writable path category.
+    *parts : str or pathlib.Path
+        Optional child path segments below the category directory.
+    create : bool, optional
+        If ``True`` create the directory and parents. Defaults to ``True``.
+
+    Returns
+    -------
+    pathlib.Path
+        Platform-aware user-writable directory.
+    """
+    base = _home_override(kind) or _platform_base(kind)
+    return _ensure(base.joinpath(*(str(p) for p in parts)), create=create)
+
+
+def data_dir(*parts: str | Path, create: bool = True) -> Path:
+    """Return a directory for persistent user data."""
+    return user_dir("data", *parts, create=create)
+
+
+def config_dir(*parts: str | Path, create: bool = True) -> Path:
+    """Return a directory for user configuration files."""
+    return user_dir("config", *parts, create=create)
+
+
+def cache_dir(*parts: str | Path, create: bool = True) -> Path:
+    """Return a directory for disposable application cache files."""
+    return user_dir("cache", *parts, create=create)
+
+
+def log_dir(*parts: str | Path, create: bool = True) -> Path:
+    """Return a directory for application logs."""
+    return user_dir("logs", *parts, create=create)
+
+
+def temp_dir(*parts: str | Path, create: bool = True) -> Path:
+    """Return a directory for temporary application files."""
+    return user_dir("temp", *parts, create=create)
+
+
+def config_file(*parts: str | Path, create_parent: bool = True) -> Path:
+    """
+    Return a path to a user configuration file.
+
+    Parameters
+    ----------
+    *parts : str or pathlib.Path
+        File path segments below the user configuration directory.
+    create_parent : bool, optional
+        If ``True`` create the parent directory. Defaults to ``True``.
+
+    Returns
+    -------
+    pathlib.Path
+        User-writable configuration file path.
+    """
+    path = config_dir(create=create_parent).joinpath(*(str(p) for p in parts))
+    if create_parent:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    return path

--- a/GONet_Wizard/resources.py
+++ b/GONet_Wizard/resources.py
@@ -1,0 +1,253 @@
+# GONet_Wizard/resources.py
+
+"""
+Package Resource Location Helpers
+=================================
+
+This module centralizes filesystem access to resources shipped inside the
+``GONet_Wizard`` Python package, such as static assets, HTML templates, icons,
+and small data files.  The helpers are intentionally small wrappers around
+:class:`pathlib.Path` because Flask, Dash, pywebview, and some scientific
+libraries still expect real filesystem paths rather than abstract package
+resources.
+
+The same helpers are safe to use in three common execution modes:
+
+- editable/source checkouts during development,
+- normal wheel/sdist installations, and
+- frozen desktop bundles created by tools such as PyInstaller.
+
+For frozen applications, the code understands common PyInstaller data-file
+layouts including ``_MEIPASS`` bundles, simple one-directory builds, and macOS
+``.app`` bundles that store data under ``Contents/Resources``.  This keeps the
+application code stable while the packaging specification is still evolving.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterable
+
+
+PACKAGE_NAME = "GONet_Wizard"
+
+
+def _dedupe_paths(paths: Iterable[Path]) -> list[Path]:
+    """
+    Return paths in order, removing duplicate string representations.
+
+    Parameters
+    ----------
+    paths : iterable of pathlib.Path
+        Candidate paths to de-duplicate.
+
+    Returns
+    -------
+    list of pathlib.Path
+        Unique paths preserving the first occurrence of each candidate.
+    """
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for path in paths:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
+def _pyinstaller_roots() -> list[Path]:
+    """
+    Return possible package roots inside a frozen PyInstaller bundle.
+
+    Returns
+    -------
+    list of pathlib.Path
+        Candidate directories ordered from most package-like to most generic.
+        The list is empty when the process is not running from a frozen bundle.
+
+    Notes
+    -----
+    PyInstaller may place collected data files under different roots depending
+    on platform and build mode.  The common layouts are covered here:
+
+    - ``sys._MEIPASS/GONet_Wizard`` and ``sys._MEIPASS`` for one-file and
+      modern one-dir bundles;
+    - ``<exe_dir>/GONet_Wizard`` and ``<exe_dir>`` for simple one-dir builds;
+    - ``Contents/Resources/GONet_Wizard`` and ``Contents/Resources`` for macOS
+      ``.app`` bundles.
+    """
+    if not getattr(sys, "frozen", False) and getattr(sys, "_MEIPASS", None) is None:
+        return []
+
+    candidates: list[Path] = []
+
+    meipass = getattr(sys, "_MEIPASS", None)
+    if meipass is not None:
+        root = Path(meipass)
+        candidates.extend([root / PACKAGE_NAME, root])
+
+    executable = getattr(sys, "executable", None)
+    if executable:
+        exe_dir = Path(executable).resolve().parent
+        candidates.extend([exe_dir / PACKAGE_NAME, exe_dir])
+
+        # PyInstaller macOS app bundles usually execute from
+        # GONet Wizard.app/Contents/MacOS while data files live under
+        # GONet Wizard.app/Contents/Resources.
+        if exe_dir.name == "MacOS" and exe_dir.parent.name == "Contents":
+            resources_dir = exe_dir.parent / "Resources"
+            candidates.extend([resources_dir / PACKAGE_NAME, resources_dir])
+
+    return _dedupe_paths(candidates)
+
+
+def _source_package_root() -> Path:
+    """
+    Return the package root for source/editable/installed execution.
+
+    Returns
+    -------
+    pathlib.Path
+        Directory containing this module, i.e. the ``GONet_Wizard`` package
+        directory.
+    """
+    return Path(__file__).resolve().parent
+
+
+def package_root() -> Path:
+    """
+    Return the best filesystem root for package-shipped resources.
+
+    Returns
+    -------
+    pathlib.Path
+        Directory that should contain package resources such as ``static`` and
+        ``gui/templates``.
+    """
+    for candidate in _pyinstaller_roots():
+        if (candidate / "static").exists() or (candidate / "gui" / "templates").exists():
+            return candidate
+    return _source_package_root()
+
+
+def resource_path(*parts: str | Path, must_exist: bool = False) -> Path:
+    """
+    Build an absolute path to a package-shipped resource.
+
+    Parameters
+    ----------
+    *parts : str or pathlib.Path
+        Path segments relative to the package resource root. With no parts, the
+        package resource root itself is returned.
+    must_exist : bool, optional
+        If ``True``, raise :class:`FileNotFoundError` when the resolved path does
+        not exist. Defaults to ``False``.
+
+    Returns
+    -------
+    pathlib.Path
+        Absolute filesystem path to the requested resource.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``must_exist`` is ``True`` and the resource cannot be found.
+    """
+    rel_parts = tuple(str(p) for p in parts)
+    candidates: Iterable[Path]
+
+    pyinstaller_roots = _pyinstaller_roots()
+    if pyinstaller_roots:
+        candidates = [root.joinpath(*rel_parts) for root in pyinstaller_roots]
+    else:
+        candidates = [package_root().joinpath(*rel_parts)]
+
+    candidates = list(candidates)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    fallback = candidates[0]
+    if must_exist:
+        searched = ", ".join(str(p) for p in candidates)
+        raise FileNotFoundError(f"Package resource not found: {searched}")
+    return fallback
+
+
+def static_dir(*parts: str | Path, must_exist: bool = False) -> Path:
+    """
+    Return a path inside the shared ``static`` resource directory.
+
+    Parameters
+    ----------
+    *parts : str or pathlib.Path
+        Optional path segments below ``static``.
+    must_exist : bool, optional
+        If ``True``, require the path to exist.
+
+    Returns
+    -------
+    pathlib.Path
+        Absolute path to the static directory or one of its children.
+    """
+    return resource_path("static", *parts, must_exist=must_exist)
+
+
+def template_dir(*parts: str | Path, must_exist: bool = False) -> Path:
+    """
+    Return a path inside the Flask/Jinja template directory.
+
+    Parameters
+    ----------
+    *parts : str or pathlib.Path
+        Optional path segments below ``gui/templates``.
+    must_exist : bool, optional
+        If ``True``, require the path to exist.
+
+    Returns
+    -------
+    pathlib.Path
+        Absolute path to the template directory or one of its children.
+    """
+    return resource_path("gui", "templates", *parts, must_exist=must_exist)
+
+
+def data_file(*parts: str | Path, must_exist: bool = False) -> Path:
+    """
+    Return a path inside the package-shipped GONet utility data directory.
+
+    Parameters
+    ----------
+    *parts : str or pathlib.Path
+        Optional path segments below ``GONet_utils/src``.
+    must_exist : bool, optional
+        If ``True``, require the path to exist.
+
+    Returns
+    -------
+    pathlib.Path
+        Absolute path to a package data file or directory.
+    """
+    return resource_path("GONet_utils", "src", *parts, must_exist=must_exist)
+
+
+def logo_path(filename: str, *, must_exist: bool = False) -> Path:
+    """
+    Return a path to a logo/icon file shipped with the package.
+
+    Parameters
+    ----------
+    filename : str
+        Logo filename under ``static/img/logo``.
+    must_exist : bool, optional
+        If ``True``, require the icon file to exist.
+
+    Returns
+    -------
+    pathlib.Path
+        Absolute path to the requested logo file.
+    """
+    return static_dir("img", "logo", filename, must_exist=must_exist)

--- a/GONet_Wizard/settings.py
+++ b/GONet_Wizard/settings.py
@@ -60,12 +60,13 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Optional
 
 from dotenv import load_dotenv
 
 from GONet_Wizard.logging_utils import get_logger
+from GONet_Wizard.resources import package_root, static_dir, template_dir
+from GONet_Wizard.paths import cache_dir, config_dir, data_dir, log_dir, temp_dir
 
 logger = get_logger(__name__)
 
@@ -115,11 +116,20 @@ class EnvVar:
         return val
 
 
-# Absolute path to the GONet_Wizard/ root directory
-ROOT = Path(__file__).resolve().parent
+# Absolute path to the GONet_Wizard package resource root.
+# This may point inside a frozen desktop bundle when packaged.
+ROOT = package_root()
 
-# Absolute path to the shared static folder
-STATIC = ROOT / "static"
+# Absolute paths to package-shipped UI resources.
+STATIC = static_dir()
+TEMPLATES = template_dir()
+
+# Platform-aware user-writable locations for packaged desktop builds.
+USER_DATA_DIR = data_dir(create=False)
+USER_CONFIG_DIR = config_dir(create=False)
+USER_CACHE_DIR = cache_dir(create=False)
+USER_LOG_DIR = log_dir(create=False)
+USER_TEMP_DIR = temp_dir(create=False)
 
 # GONet variables
 GONET_USER = EnvVar("GONET_USER", "pi")

--- a/GONet_Wizard/ui/dash_runner.py
+++ b/GONet_Wizard/ui/dash_runner.py
@@ -38,6 +38,7 @@ Functions
 
 from __future__ import annotations
 
+from queue import Empty, Queue
 import socket
 import threading
 import time
@@ -107,9 +108,14 @@ class _RunnerState:
         Background thread running the Dash server.
     port : :class:`int`
         Port bound by the server.
+    startup_errors : :class:`queue.Queue`
+        Queue used to report startup exceptions from the background thread to
+        the caller waiting for the port to open.
     """
+
     thread: threading.Thread
     port: int
+    startup_errors: Queue[BaseException]
 
 
 # Global registry: (app_key, port) -> running thread
@@ -141,7 +147,49 @@ def _suppress_startup_noise() -> None:
         pass
 
 
-def _run_dash_server(spec: DashLaunchSpec, *, debug: bool, port: int) -> None:
+def _raise_startup_error(
+    startup_errors: Queue[BaseException] | None,
+    *,
+    app_key: str | None = None,
+) -> None:
+    """
+    Raise the first queued Dash startup exception, if one is available.
+
+    Parameters
+    ----------
+    startup_errors : :class:`queue.Queue` or None
+        Queue populated by the Dash server thread when startup fails.
+    app_key : :class:`str`, optional
+        Human-readable app key included in the raised message.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    RuntimeError
+        If a startup exception has been reported by the background thread.
+    """
+    if startup_errors is None:
+        return
+
+    try:
+        exc = startup_errors.get_nowait()
+    except Empty:
+        return
+
+    label = f" {app_key!r}" if app_key else ""
+    raise RuntimeError(f"Dash server{label} failed during startup: {exc}") from exc
+
+
+def _run_dash_server(
+    spec: DashLaunchSpec,
+    *,
+    debug: bool,
+    port: int,
+    startup_errors: Queue[BaseException] | None = None,
+) -> None:
     """
     Configure and run the Dash server (blocking).
 
@@ -153,31 +201,46 @@ def _run_dash_server(spec: DashLaunchSpec, *, debug: bool, port: int) -> None:
         Whether to run in Dash debug mode.
     port : :class:`int`
         Port to bind to on localhost.
+    startup_errors : :class:`queue.Queue`, optional
+        Queue used to report exceptions to the launching thread while it waits
+        for the server port to become available.
 
     Returns
     -------
     None
     """
-    if not debug:
-        _suppress_startup_noise()
+    try:
+        if not debug:
+            _suppress_startup_noise()
 
-    spec.configure(spec.app)
-    spec.app.layout = spec.layout(spec.app)
+        spec.configure(spec.app)
+        spec.app.layout = spec.layout(spec.app)
 
-    if spec.index_string is not None:
-        spec.app.index_string = spec.index_string()
+        if spec.index_string is not None:
+            spec.app.index_string = spec.index_string()
 
-    spec.register_callbacks()
+        spec.register_callbacks()
 
-    spec.app.run_server(port=port, debug=debug, use_reloader=False)
+        spec.app.run_server(
+            host="127.0.0.1",
+            port=port,
+            debug=debug,
+            use_reloader=False,
+        )
+    except BaseException as exc:
+        if startup_errors is not None:
+            startup_errors.put(exc)
+        raise
 
 
 def wait_for_port(
     host: str,
     port: int,
     *,
-    timeout: float = 10.0,
-    poll_interval: float = 0.05,
+    timeout: float = 30.0,
+    poll_interval: float = 0.1,
+    startup_errors: Queue[BaseException] | None = None,
+    app_key: str | None = None,
 ) -> None:
     """
     Block until a TCP port is accepting connections.
@@ -189,9 +252,16 @@ def wait_for_port(
     port : :class:`int`
         TCP port number.
     timeout : :class:`float`, optional
-        Maximum time to wait in seconds. Defaults to ``10.0``.
+        Maximum time to wait in seconds. Defaults to ``30.0``. Frozen desktop
+        apps can take longer than source-mode runs to import, configure, and
+        bind Dash apps.
     poll_interval : :class:`float`, optional
-        Time between connection attempts in seconds. Defaults to ``0.05``.
+        Time between connection attempts in seconds. Defaults to ``0.1``.
+    startup_errors : :class:`queue.Queue`, optional
+        Queue populated by the background server thread if startup fails before
+        the port opens.
+    app_key : :class:`str`, optional
+        App key included in startup error messages.
 
     Returns
     -------
@@ -200,11 +270,14 @@ def wait_for_port(
     Raises
     ------
     RuntimeError
-        If the port does not open within ``timeout`` seconds.
+        If the port does not open within ``timeout`` seconds, or if the Dash
+        server reports a startup exception before the port opens.
     """
     deadline = time.monotonic() + timeout
 
     while time.monotonic() < deadline:
+        _raise_startup_error(startup_errors, app_key=app_key)
+
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             sock.settimeout(poll_interval)
             try:
@@ -213,6 +286,7 @@ def wait_for_port(
             except (ConnectionRefusedError, OSError):
                 time.sleep(poll_interval)
 
+    _raise_startup_error(startup_errors, app_key=app_key)
     raise RuntimeError(
         f"Dash server did not open port {host}:{port} within {timeout:.1f}s"
     )
@@ -227,6 +301,7 @@ def ensure_dash_running(
     *,
     debug: bool,
     port: int = 8050,
+    startup_timeout: float = 30.0,
 ) -> str:
     """
     Ensure a Dash server is running for the given spec and port, and return its URL.
@@ -241,11 +316,19 @@ def ensure_dash_running(
         Whether to run Dash in debug mode.
     port : :class:`int`, optional
         Port to bind to on localhost. Defaults to ``8050``.
+    startup_timeout : :class:`float`, optional
+        Maximum time to wait for the server port to open. Defaults to ``30.0``.
 
     Returns
     -------
     :class:`str`
         Local URL for the running server (e.g., ``"http://127.0.0.1:8050"``).
+
+    Raises
+    ------
+    RuntimeError
+        If the server fails during startup or does not open its port before the
+        timeout expires.
     """
     key = (spec.app_key, port)
 
@@ -253,15 +336,37 @@ def ensure_dash_running(
     if existing is not None and existing.thread.is_alive():
         return f"http://127.0.0.1:{port}"
 
+    startup_errors: Queue[BaseException] = Queue()
+
     t = threading.Thread(
         target=_run_dash_server,
-        kwargs={"spec": spec, "debug": debug, "port": port},
+        kwargs={
+            "spec": spec,
+            "debug": debug,
+            "port": port,
+            "startup_errors": startup_errors,
+        },
         daemon=True,
     )
     t.start()
 
-    _RUNNERS[key] = _RunnerState(thread=t, port=port)
+    _RUNNERS[key] = _RunnerState(
+        thread=t,
+        port=port,
+        startup_errors=startup_errors,
+    )
 
-    wait_for_port("127.0.0.1", port, timeout=10.0)
+    try:
+        wait_for_port(
+            "127.0.0.1",
+            port,
+            timeout=startup_timeout,
+            startup_errors=startup_errors,
+            app_key=spec.app_key,
+        )
+    except RuntimeError:
+        if not t.is_alive():
+            _RUNNERS.pop(key, None)
+        raise
 
     return f"http://127.0.0.1:{port}"

--- a/GONet_Wizard/ui/server.py
+++ b/GONet_Wizard/ui/server.py
@@ -22,6 +22,7 @@ The server is managed as a process singleton using module-level state:
 - ``_app`` holds the :class:`flask.Flask` instance
 - ``_server_thread`` holds the background thread running the server
 - ``_server_port`` stores the configured port
+- ``_server_lock`` serializes startup so callers never open windows early
 
 Functions
 ---------
@@ -29,6 +30,8 @@ Functions
     Create and configure the unified Flask application.
 :func:`ensure_server_running`
     Start the Flask server thread if needed and return the active port.
+:func:`wait_for_server`
+    Block until the local Flask server answers its health endpoint.
 :func:`get_app`
     Return the singleton Flask app instance, creating it if needed.
 :func:`get_server_port`
@@ -40,6 +43,8 @@ from __future__ import annotations
 
 import threading
 import time
+import urllib.error
+import urllib.request
 from typing import Optional
 
 from flask import Flask
@@ -50,6 +55,9 @@ from GONet_Wizard import settings
 _server_thread: Optional[threading.Thread] = None
 _server_port: int = 5050
 _app: Optional[Flask] = None
+_server_lock = threading.Lock()
+_HEALTH_PATH = "/health"
+_HEALTH_BODY = "ok"
 
 
 def create_app() -> Flask:
@@ -72,9 +80,14 @@ def create_app() -> Flask:
     """
     app = Flask(
         "GONetWizardUI",
-        template_folder=str(settings.ROOT / "gui" / "templates"),
-        static_folder=settings.STATIC,
+        template_folder=str(settings.TEMPLATES),
+        static_folder=str(settings.STATIC),
     )
+
+    @app.get(_HEALTH_PATH)
+    def health_check():
+        """Return a minimal readiness response for desktop startup checks."""
+        return _HEALTH_BODY, 200, {"Content-Type": "text/plain; charset=utf-8"}
 
     # Register the launcher routes as a blueprint
     try:
@@ -91,6 +104,66 @@ def create_app() -> Flask:
         raise RuntimeError("Failed to register preview blueprint.") from e
 
     return app
+
+
+def wait_for_server(
+    host: str,
+    port: int,
+    *,
+    path: str = _HEALTH_PATH,
+    timeout: float = 10.0,
+    poll_interval: float = 0.1,
+) -> None:
+    """
+    Block until the unified UI server answers its health endpoint.
+
+    The desktop bundle starts Flask in a background thread before creating the
+    pywebview window. Frozen apps can take slightly longer to bind and serve
+    their first request, so probing the HTTP health endpoint avoids opening a
+    blank webview against a server that is not ready yet.
+
+    Parameters
+    ----------
+    host : :class:`str`
+        Hostname or IP address to probe, usually ``"127.0.0.1"``.
+    port : :class:`int`
+        TCP port used by the unified UI server.
+    path : :class:`str`, optional
+        Health endpoint path. Defaults to ``"/health"``.
+    timeout : :class:`float`, optional
+        Maximum time to wait in seconds. Defaults to ``10.0``.
+    poll_interval : :class:`float`, optional
+        Time between readiness checks in seconds. Defaults to ``0.1``.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    RuntimeError
+        If the health endpoint does not respond before ``timeout`` expires.
+    """
+    url = f"http://{host}:{port}{path}"
+    deadline = time.monotonic() + timeout
+    last_error: BaseException | None = None
+
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=min(1.0, poll_interval)) as response:
+                body = response.read().decode("utf-8", errors="replace").strip()
+                if response.status == 200 and body == _HEALTH_BODY:
+                    return
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = exc
+
+        time.sleep(poll_interval)
+
+    detail = f" Last error: {last_error}" if last_error is not None else ""
+    raise RuntimeError(
+        f"Unified UI server did not become ready at {url!r} "
+        f"within {timeout:.1f}s.{detail}"
+    )
 
 
 def ensure_server_running(*, port: int = 5050) -> int:
@@ -118,31 +191,44 @@ def ensure_server_running(*, port: int = 5050) -> int:
     """
     global _server_thread, _server_port, _app
 
-    if _server_thread is not None and _server_thread.is_alive():
+    with _server_lock:
+        if _server_thread is not None and _server_thread.is_alive():
+            return _server_port
+
+        _server_port = port
+        _app = create_app()
+
+        def _run() -> None:
+            # threaded=True allows concurrent requests from multiple windows
+            _app.run(
+                host="127.0.0.1",
+                port=_server_port,
+                debug=False,
+                threaded=True,
+                use_reloader=False,
+            )
+
+        try:
+            _server_thread = threading.Thread(target=_run, daemon=True)
+            _server_thread.start()
+        except Exception as e:
+            _server_thread = None
+            _app = None
+            raise RuntimeError("Failed to start unified UI server thread.") from e
+
+        try:
+            wait_for_server("127.0.0.1", _server_port, timeout=15.0)
+        except RuntimeError as e:
+            if _server_thread is not None and not _server_thread.is_alive():
+                _server_thread = None
+                _app = None
+                raise RuntimeError(
+                    "Unified UI server exited before it became ready. "
+                    "The requested port may already be in use."
+                ) from e
+            raise
+
         return _server_port
-
-    _server_port = port
-    _app = create_app()
-
-    def _run() -> None:
-        # threaded=True allows concurrent requests from multiple windows
-        _app.run(
-            host="127.0.0.1",
-            port=_server_port,
-            debug=False,
-            threaded=True,
-            use_reloader=False,
-        )
-
-    try:
-        _server_thread = threading.Thread(target=_run, daemon=True)
-        _server_thread.start()
-    except Exception as e:
-        raise RuntimeError("Failed to start unified UI server thread.") from e
-
-    # Give it a moment to bind the port
-    time.sleep(0.25)
-    return _server_port
 
 
 def get_app() -> Flask:

--- a/README.rst
+++ b/README.rst
@@ -28,14 +28,28 @@ Includes an interactive Dash dashboard, CLI utilities, and tools for remote inte
 Installation
 ------------
 
-To install the latest version directly from GitHub:
+GONet Wizard has two installation paths, depending on how you want to use it.
+
+**Desktop app for GUI users**
+
+Downloadable desktop installers from the
+`GitHub Releases page <https://github.com/gterreran/GONet_Wizard/releases>`_
+are intended for users who want to launch GONet Wizard by double-clicking the
+application icon. The desktop app opens the graphical launcher and does not
+install the command-line tools into your shell ``PATH``.
+
+**Python package for CLI users**
+
+If you want to run terminal commands such as ``GONet_Wizard show``,
+``GONet_Wizard extract``, or ``GONet_Wizard gui``, install the Python package:
 
 .. code-block:: bash
 
    pip install git+https://github.com/gterreran/GONet_Wizard.git
 
 It is recommended to first create and activate a clean environment using Python ≥3.10.
-See the full `Documentation <https://gterreran.github.io/GONet_Wizard/installation.html>`_ for more installation options, including Windows installation.
+See the full `Documentation <https://gterreran.github.io/GONet_Wizard/installation.html>`_
+for more installation options, including desktop-app and Windows notes.
 
 ----
 

--- a/build_tools/macos/README.md
+++ b/build_tools/macos/README.md
@@ -1,0 +1,53 @@
+# macOS DMG build helper
+
+This folder contains the first unsigned macOS DMG wrapper for the PyInstaller
+GUI app. It is intended for local testing and GitHub release candidates, not for
+App Store distribution.
+
+Run from the repository root after the GUI `.app` build is working:
+
+```bash
+build_tools/macos/build_dmg.sh
+```
+
+The script will reuse `dist/GONet Wizard.app` if it already exists. If the app is
+missing, it will build it with:
+
+```bash
+python -m PyInstaller build_tools/pyinstaller/gonet_wizard_gui.spec --clean --noconfirm
+```
+
+Expected output:
+
+```text
+dist/GONet-Wizard-<version>-macOS-<arch>-unsigned.dmg
+```
+
+Useful options:
+
+```bash
+# Require an existing .app and only create the DMG
+build_tools/macos/build_dmg.sh --skip-pyinstaller
+
+# Force a fresh PyInstaller app build before making the DMG
+build_tools/macos/build_dmg.sh --force-pyinstaller
+
+# Choose a custom output name
+build_tools/macos/build_dmg.sh --dmg-name GONet-Wizard-test.dmg
+
+# Override the version label used in the default filename and README
+build_tools/macos/build_dmg.sh --version 0.3.0-test
+```
+
+The DMG contains:
+
+- `GONet Wizard.app`
+- an `Applications` shortcut
+- `README-FIRST.txt` with unsigned-build launch notes
+
+Because this first DMG is unsigned and not notarized, macOS Gatekeeper may block
+first launch on another machine. For internal testing, right-click/control-click
+the app and choose **Open**, or use **System Settings > Privacy & Security** to
+allow the app after the first blocked launch.
+
+For GitHub-based distribution, keep generated DMGs out of the repository and upload them as GitHub Release assets. The `Build macOS DMG` GitHub Actions workflow can build a short-lived test artifact manually, or attach the DMG to a draft release when a `v*` tag is pushed.

--- a/build_tools/macos/build_dmg.sh
+++ b/build_tools/macos/build_dmg.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Build an unsigned macOS DMG for local testing / GitHub release candidates.
+#
+# This script assumes the PyInstaller GUI app is available at
+# dist/GONet Wizard.app. If it is missing, the script builds it using the
+# repository PyInstaller spec before creating the DMG.
+
+set -euo pipefail
+
+APP_NAME="GONet Wizard"
+VOLUME_NAME="GONet Wizard"
+RUN_PYINSTALLER=auto
+CLEAN_STAGING=1
+APP_PATH_CUSTOM=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+DIST_DIR="${REPO_ROOT}/dist"
+BUILD_DIR="${REPO_ROOT}/build"
+APP_PATH="${DIST_DIR}/${APP_NAME}.app"
+OUTPUT_DIR="${DIST_DIR}"
+ARCH_NAME="$(uname -m)"
+APP_VERSION=""
+DMG_NAME=""
+DMG_NAME_CUSTOM=0
+
+resolve_version() {
+    if [[ -n "${APP_VERSION}" ]]; then
+        printf '%s\n' "${APP_VERSION}"
+        return 0
+    fi
+
+    python - <<'PYVERSION' 2>/dev/null || true
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    print(version("GONet_Wizard"))
+except PackageNotFoundError:
+    pass
+PYVERSION
+}
+
+sanitize_for_filename() {
+    # Keep release filenames shell- and URL-friendly without changing the
+    # human-facing version used inside the README.
+    sed -E 's/[^A-Za-z0-9._+-]+/-/g; s/^-+//; s/-+$//'
+}
+
+usage() {
+    cat <<USAGE
+Usage: build_tools/macos/build_dmg.sh [options]
+
+Build an unsigned drag-and-drop macOS DMG for GONet Wizard.
+
+Options:
+  --app-path PATH       Use an existing .app bundle instead of dist/GONet Wizard.app.
+  --output-dir PATH     Directory where the DMG will be written. Default: dist/.
+  --dmg-name NAME       Output DMG filename. Default: versioned unsigned name.
+  --version VERSION     Version label to include in the default DMG name.
+  --volume-name NAME    Mounted volume name. Default: ${VOLUME_NAME}
+  --skip-pyinstaller   Do not run PyInstaller; fail if the .app bundle is missing.
+  --force-pyinstaller  Always rebuild the .app bundle before creating the DMG.
+  --no-clean-staging   Leave build/dmg-staging in place for inspection.
+  -h, --help           Show this help message.
+
+Examples:
+  build_tools/macos/build_dmg.sh
+  build_tools/macos/build_dmg.sh --skip-pyinstaller
+  build_tools/macos/build_dmg.sh --dmg-name GONet-Wizard-test.dmg
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --app-path)
+            APP_PATH="$2"
+            APP_PATH_CUSTOM=1
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --dmg-name)
+            DMG_NAME="$2"
+            DMG_NAME_CUSTOM=1
+            shift 2
+            ;;
+        --version)
+            APP_VERSION="$2"
+            shift 2
+            ;;
+        --volume-name)
+            VOLUME_NAME="$2"
+            shift 2
+            ;;
+        --skip-pyinstaller)
+            RUN_PYINSTALLER=never
+            shift
+            ;;
+        --force-pyinstaller)
+            RUN_PYINSTALLER=always
+            shift
+            ;;
+        --no-clean-staging)
+            CLEAN_STAGING=0
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "ERROR: DMG creation requires macOS." >&2
+    exit 1
+fi
+
+if ! command -v hdiutil >/dev/null 2>&1; then
+    echo "ERROR: hdiutil was not found. DMG creation requires macOS hdiutil." >&2
+    exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+RESOLVED_VERSION="$(resolve_version | head -n 1)"
+if [[ -z "${RESOLVED_VERSION}" ]]; then
+    if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        RESOLVED_VERSION="$(git describe --tags --dirty --always 2>/dev/null || true)"
+    fi
+fi
+if [[ -z "${RESOLVED_VERSION}" ]]; then
+    RESOLVED_VERSION="dev"
+fi
+
+SAFE_VERSION="$(printf '%s' "${RESOLVED_VERSION}" | sanitize_for_filename)"
+if [[ -z "${SAFE_VERSION}" ]]; then
+    SAFE_VERSION="dev"
+fi
+
+if [[ "${DMG_NAME_CUSTOM}" == "0" ]]; then
+    DMG_NAME="GONet-Wizard-${SAFE_VERSION}-macOS-${ARCH_NAME}-unsigned.dmg"
+fi
+
+if [[ "${RUN_PYINSTALLER}" == "always" || ( "${RUN_PYINSTALLER}" == "auto" && "${APP_PATH_CUSTOM}" == "0" && ! -d "${APP_PATH}" ) ]]; then
+    echo "Building ${APP_NAME}.app with PyInstaller..."
+    python -m PyInstaller build_tools/pyinstaller/gonet_wizard_gui.spec --clean --noconfirm
+fi
+
+if [[ ! -d "${APP_PATH}" ]]; then
+    cat >&2 <<ERROR
+ERROR: App bundle not found: ${APP_PATH}
+
+Build it first with:
+  python -m PyInstaller build_tools/pyinstaller/gonet_wizard_gui.spec --clean --noconfirm
+
+or pass --app-path PATH to an existing app bundle.
+ERROR
+    exit 1
+fi
+
+mkdir -p "${OUTPUT_DIR}" "${BUILD_DIR}"
+
+STAGING_DIR="${BUILD_DIR}/dmg-staging"
+DMG_PATH="${OUTPUT_DIR}/${DMG_NAME}"
+
+rm -rf "${STAGING_DIR}"
+mkdir -p "${STAGING_DIR}"
+
+# Preserve macOS bundle metadata more reliably than a plain cp.
+ditto "${APP_PATH}" "${STAGING_DIR}/${APP_NAME}.app"
+ln -s /Applications "${STAGING_DIR}/Applications"
+
+cat > "${STAGING_DIR}/README-FIRST.txt" <<README
+GONet Wizard for macOS
+======================
+
+Version: ${RESOLVED_VERSION}
+
+This is an unsigned test DMG intended for GitHub release testing.
+
+Install:
+1. Drag "${APP_NAME}.app" to the Applications shortcut.
+2. Launch it from Applications.
+
+Unsigned build note:
+macOS may block the first launch because this build is not signed or notarized.
+For internal testing, right-click/control-click the app and choose Open, or open
+System Settings > Privacy & Security and allow the app after the first blocked
+launch.
+
+The command-line interface is still available through the normal Python package
+installation path for power users and developers.
+README
+
+rm -f "${DMG_PATH}"
+
+echo "Creating ${DMG_PATH}..."
+echo "Version label: ${RESOLVED_VERSION}"
+hdiutil create \
+    -volname "${VOLUME_NAME}" \
+    -srcfolder "${STAGING_DIR}" \
+    -ov \
+    -format UDZO \
+    "${DMG_PATH}"
+
+if [[ "${CLEAN_STAGING}" == "1" ]]; then
+    rm -rf "${STAGING_DIR}"
+fi
+
+echo "DMG created: ${DMG_PATH}"

--- a/build_tools/pyinstaller/README.md
+++ b/build_tools/pyinstaller/README.md
@@ -1,0 +1,105 @@
+# PyInstaller build scaffolding
+
+This folder contains the first raw frozen-build scaffolding for GONet Wizard.
+It is intentionally **not** an installer yet.  The goal is to prove that the app
+can be frozen while still finding bundled templates, static files, icons, and
+small package data files.
+
+Run all commands from the repository root.
+
+## Install build dependencies
+
+```bash
+pip install -e ".[build]"
+```
+
+## GUI build
+
+```bash
+pyinstaller build_tools/pyinstaller/gonet_wizard_gui.spec --clean --noconfirm
+```
+
+Expected outputs:
+
+- macOS: `dist/GONet Wizard.app`
+- Windows/Linux raw build: `dist/GONet Wizard/`
+
+The GUI spec is windowed/console-free because this is the executable that will
+later become the double-clickable desktop app.
+
+
+## Unsigned macOS DMG
+
+Once the raw macOS `.app` passes the smoke checks, create a test DMG with:
+
+```bash
+build_tools/macos/build_dmg.sh
+```
+
+Expected output:
+
+```text
+dist/GONet-Wizard-macOS-<arch>-unsigned.dmg
+```
+
+The DMG is intentionally unsigned and not notarized at this stage. It is suitable
+for local testing and GitHub release candidates, but macOS Gatekeeper may block
+first launch on another machine. See `build_tools/macos/README.md` for the
+internal-testing install flow.
+
+## CLI build
+
+```bash
+pyinstaller build_tools/pyinstaller/gonet_wizard_cli.spec --clean --noconfirm
+```
+
+Expected output:
+
+- `dist/gonet-wizard/`
+
+The CLI build keeps a console window and is mainly useful as a diagnostic/power
+user executable.
+
+
+## Size-cleanup notes
+
+The specs intentionally keep Dash component package data broad because Dash reads
+metadata and serves JavaScript/CSS sidecar files at runtime.  Python hidden
+imports are filtered separately in `_runtime_selection.py` so development,
+testing, notebook, and documentation modules do not inflate the frozen app.
+
+If a future build fails with a missing runtime module, prefer adding a narrow
+package or module to `RUNTIME_HIDDENIMPORT_PACKAGES` rather than reverting to
+unfiltered `collect_submodules(...)` calls.
+
+For the cleanest release-sized build, build from a fresh environment containing
+only the runtime dependencies plus the `build` extra, not the full `dev` or
+`docs` extras.  Keep using the dev environment for tests.
+
+## First smoke checks
+
+After building, test the following before making installer work:
+
+```bash
+# from the frozen CLI folder
+./gonet-wizard --version
+./gonet-wizard --help
+
+# from the frozen GUI app/folder
+# launch GONet Wizard and confirm the launcher page, forms, CSS, JS, and icons load
+```
+
+Also check workflows that touch bundled resources:
+
+- launcher opens with the normal stylesheet and logo;
+- `show` form opens and renders a preview window;
+- `extract` form opens and the extraction Dash app loads its assets;
+- `dashboard` launches and its Dash assets load;
+- no `file_system_backend/`, logs, cache, or runtime temp directories appear in
+  the installed/frozen app directory.
+
+## Notes
+
+The build specs keep package data under `GONet_Wizard/...` in the frozen bundle.
+The runtime helper `GONet_Wizard.resources` is responsible for finding those
+resources in source checkouts, installed wheels, and frozen apps.

--- a/build_tools/pyinstaller/_runtime_selection.py
+++ b/build_tools/pyinstaller/_runtime_selection.py
@@ -1,0 +1,158 @@
+"""Shared PyInstaller collection rules for GONet Wizard builds.
+
+The first working frozen builds intentionally used broad hidden-import
+collection for Dash, Plotly, Flask, and pywebview. That was a safe way to prove
+that the app could run, but it also pulled in development, testing, notebook,
+and documentation helpers that are not part of the desktop runtime.
+
+This module keeps the data collection broad where Dash needs package sidecar
+assets, while filtering hidden imports to runtime-oriented modules only.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from PyInstaller.utils.hooks import (
+    can_import_module,
+    collect_data_files,
+    collect_submodules,
+)
+
+
+GONET_DATA_INCLUDES = [
+    "static/**/*",
+    "gui/templates/**/*.html",
+    "GONet_utils/src/*.yaml",
+]
+
+# Dash component packages read package metadata and serve bundled JS/CSS assets
+# from their installed package directories at runtime. Keep package data broad;
+# the size cleanup below applies to Python hidden imports, not these sidecars.
+DASH_COMPONENT_PACKAGES = [
+    "dash",
+    "dash_daq",
+    "dash_extensions",
+    "dash_core_components",
+    "dash_html_components",
+    "dash_table",
+]
+
+# Packages for which PyInstaller needs some dynamic-module help. These are
+# filtered by ``is_runtime_module`` before being passed as hidden imports.
+RUNTIME_HIDDENIMPORT_PACKAGES = [
+    "GONet_Wizard",
+    "dash",
+    "dash_extensions",
+    "dash_daq",
+    "plotly",
+    "flask",
+    "webview",
+]
+
+# Modules that were observed to bloat the frozen app or produce irrelevant
+# import warnings during broad collection. They are not required by the desktop
+# runtime and should stay out of raw GUI/CLI builds.
+EXCLUDED_MODULE_PREFIXES = [
+    "_pytest",
+    # Dash imports dash.development.base_component at runtime, so do not
+    # exclude the whole dash.development package. Exclude only the build-time
+    # component-generation helpers that caused the original bundle bloat.
+    "dash.development._jl_components_generation",
+    "dash.development._r_components_generation",
+    "dash.development.build_process",
+    "dash.development.component_generator",
+    "dash.development.update_components",
+    "dash.testing",
+    # Dash imports dash._jupyter from dash.dash at import time even when
+    # notebook integration is never used. Keep the small internal Dash module,
+    # but continue excluding actual Jupyter/IPython runtime packages below.
+    "docutils",
+    "IPython",
+    "ipykernel",
+    "jupyter",
+    "jupyter_client",
+    "jupyter_core",
+    "myst_parser",
+    "nbclient",
+    "nbconvert",
+    "nbformat",
+    "notebook",
+    "plotly.conftest",
+    "plotly.io._sg_scraper",
+    "plotly.matplotlylib.tests",
+    "plotly.matplotlylib.mplexporter.tests",
+    "pytest",
+    "sphinx",
+    "sphinx_autodoc_typehints",
+    "sphinx_rtd_theme",
+    "sphinxcontrib",
+    "webview.platforms.android",
+]
+
+# ``Analysis(excludes=...)`` uses import-style names. Passing prefixes here is
+# still useful because PyInstaller treats excluded package names as roots to skip.
+EXCLUDES = sorted(set(EXCLUDED_MODULE_PREFIXES))
+
+
+def _matches_prefix(name: str, prefix: str) -> bool:
+    """Return True if ``name`` is ``prefix`` or a submodule below it."""
+    return name == prefix or name.startswith(f"{prefix}.")
+
+
+def is_runtime_module(name: str) -> bool:
+    """Return True if ``name`` should be eligible as a frozen hidden import."""
+    if any(_matches_prefix(name, prefix) for prefix in EXCLUDED_MODULE_PREFIXES):
+        return False
+
+    parts = set(name.split("."))
+    if "tests" in parts or "testing" in parts:
+        return False
+
+    if name.endswith(".conftest") or ".conftest." in name:
+        return False
+
+    return True
+
+
+def unique(items: Iterable[str]) -> list[str]:
+    """Return items with duplicates removed while preserving first occurrence."""
+    return list(dict.fromkeys(items))
+
+
+def collect_gonet_datas() -> list[tuple[str, str]]:
+    """Collect GONet Wizard package data needed by source and frozen GUIs."""
+    return collect_data_files("GONet_Wizard", includes=GONET_DATA_INCLUDES)
+
+
+def collect_dash_component_datas() -> list[tuple[str, str]]:
+    """Collect non-Python data files used by Dash component packages."""
+    datas: list[tuple[str, str]] = []
+    for package in DASH_COMPONENT_PACKAGES:
+        if can_import_module(package):
+            datas += collect_data_files(package, include_py_files=False)
+    return datas
+
+
+def collect_runtime_submodules(package: str) -> list[str]:
+    """Collect runtime hidden imports for a package, excluding dev/test modules."""
+    if not can_import_module(package):
+        return []
+
+    try:
+        return collect_submodules(package, filter=is_runtime_module)
+    except TypeError:
+        # Older PyInstaller versions did not expose the filter keyword. The
+        # project build extra currently asks for PyInstaller >= 6, but this
+        # fallback keeps the spec readable if someone tests an older toolchain.
+        return [name for name in collect_submodules(package) if is_runtime_module(name)]
+
+
+def collect_runtime_hiddenimports(
+    packages: Iterable[str] = RUNTIME_HIDDENIMPORT_PACKAGES,
+) -> list[str]:
+    """Collect filtered hidden imports for all runtime packages."""
+    hiddenimports: list[str] = []
+    for package in packages:
+        hiddenimports += collect_runtime_submodules(package)
+    return unique(hiddenimports)

--- a/build_tools/pyinstaller/gonet_wizard_cli.spec
+++ b/build_tools/pyinstaller/gonet_wizard_cli.spec
@@ -1,0 +1,75 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller spec for a console-capable GONet Wizard CLI executable.
+
+Build from the repository root with:
+
+    pyinstaller build_tools/pyinstaller/gonet_wizard_cli.spec --clean --noconfirm
+
+This is optional for end users, but useful as a frozen diagnostic executable and
+for power users who want CLI functionality without a Python environment.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path.cwd()
+PACKAGE_ROOT = ROOT / "GONet_Wizard"
+PYINSTALLER_ROOT = ROOT / "build_tools" / "pyinstaller"
+sys.path.insert(0, str(PYINSTALLER_ROOT))
+
+from _runtime_selection import (  # noqa: E402
+    EXCLUDES,
+    collect_dash_component_datas,
+    collect_gonet_datas,
+    collect_runtime_hiddenimports,
+)
+
+
+APP_NAME = "gonet-wizard"
+
+datas = collect_gonet_datas() + collect_dash_component_datas()
+hiddenimports = collect_runtime_hiddenimports()
+
+
+a = Analysis(
+    [str(PACKAGE_ROOT / "__main__.py")],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[str(PYINSTALLER_ROOT / "hooks")],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=EXCLUDES,
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name=APP_NAME,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name=APP_NAME,
+)

--- a/build_tools/pyinstaller/gonet_wizard_gui.spec
+++ b/build_tools/pyinstaller/gonet_wizard_gui.spec
@@ -1,0 +1,105 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller spec for the double-clickable GONet Wizard desktop GUI.
+
+Build from the repository root with:
+
+    pyinstaller build_tools/pyinstaller/gonet_wizard_gui.spec --clean --noconfirm
+
+This spec intentionally builds an ``onedir`` app rather than a ``onefile`` app.
+That keeps startup faster and makes macOS signing/notarization easier later.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path.cwd()
+PACKAGE_ROOT = ROOT / "GONet_Wizard"
+PYINSTALLER_ROOT = ROOT / "build_tools" / "pyinstaller"
+sys.path.insert(0, str(PYINSTALLER_ROOT))
+
+from _runtime_selection import (  # noqa: E402
+    EXCLUDES,
+    collect_dash_component_datas,
+    collect_gonet_datas,
+    collect_runtime_hiddenimports,
+)
+
+
+APP_NAME = "GONet Wizard"
+BUNDLE_IDENTIFIER = "org.adlerplanetarium.gonetwizard"
+
+# Keep GONet data under GONet_Wizard/... inside the frozen bundle. The runtime
+# helpers in GONet_Wizard.resources know how to locate this layout.
+datas = collect_gonet_datas() + collect_dash_component_datas()
+
+# Dash/Flask callbacks, pywebview backends, and command modules include a few
+# dynamically discovered imports. Collect them with a runtime filter so testing,
+# notebook, and documentation helpers do not inflate the frozen app.
+hiddenimports = collect_runtime_hiddenimports()
+
+icon = PACKAGE_ROOT / "static" / "img" / "logo" / "GONet_Wizard.ico"
+if sys.platform == "darwin":
+    icon = PACKAGE_ROOT / "static" / "img" / "logo" / "GONet_Wizard.icns"
+
+
+a = Analysis(
+    [str(PACKAGE_ROOT / "desktop.py")],
+    pathex=[str(ROOT)],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[str(PYINSTALLER_ROOT / "hooks")],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=EXCLUDES,
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name=APP_NAME,
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=str(icon),
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name=APP_NAME,
+)
+
+if sys.platform == "darwin":
+    app = BUNDLE(
+        coll,
+        name=f"{APP_NAME}.app",
+        icon=str(icon),
+        bundle_identifier=BUNDLE_IDENTIFIER,
+        info_plist={
+            "CFBundleName": APP_NAME,
+            "CFBundleDisplayName": APP_NAME,
+            "CFBundleIdentifier": BUNDLE_IDENTIFIER,
+            "NSHighResolutionCapable": "True",
+        },
+    )

--- a/build_tools/pyinstaller/hooks/hook-GONet_Wizard.py
+++ b/build_tools/pyinstaller/hooks/hook-GONet_Wizard.py
@@ -1,0 +1,23 @@
+"""PyInstaller hook for GONet Wizard package data and runtime submodules."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# Import the shared collection rules from the parent pyinstaller folder. PyInstaller
+# executes hooks in its own context, so make the sibling helper explicit.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from _runtime_selection import (  # noqa: E402
+    EXCLUDES,
+    collect_dash_component_datas,
+    collect_gonet_datas,
+    collect_runtime_hiddenimports,
+)
+
+
+datas = collect_gonet_datas() + collect_dash_component_datas()
+hiddenimports = collect_runtime_hiddenimports(["GONet_Wizard"])
+excludedimports = EXCLUDES

--- a/docs/source/cli_reference/index.rst
+++ b/docs/source/cli_reference/index.rst
@@ -15,6 +15,13 @@ For a conceptual overview of the available tools, see :doc:`Tools guide <../tool
 For implementation details about how commands are declared and dispatched, see
 :doc:`command-system developer notes <../developer_notes/command_system>`.
 
+.. important::
+
+   The desktop installer/DMG is a GUI-first distribution path and does not add
+   command-line entry points to your shell. To use this CLI reference, install
+   the Python package with ``pip`` or ``pipx`` so that ``GONet_Wizard`` and
+   ``gonet-wizard`` are available from the terminal.
+
 Basic Usage
 -----------
 

--- a/docs/source/developer_notes/index.rst
+++ b/docs/source/developer_notes/index.rst
@@ -30,6 +30,10 @@ Architecture Map
      - How the dashboard loads extraction products, discovers fields, filters data, and exports subsets.
    * - :doc:`contributor workflows developer notes <contributor_workflows>`
      - Practical recipes for adding commands, GUI forms, Dash tools, and extractors.
+   * - :doc:`desktop packaging developer notes <packaging>`
+     - How the desktop entry point, resource paths, PyInstaller specs, and macOS DMG wrapper fit together.
+   * - :doc:`release workflow developer notes <release_workflow>`
+     - How to build, test, and publish large installer artifacts without committing them to git.
 
 .. toctree::
    :maxdepth: 2
@@ -40,6 +44,8 @@ Architecture Map
    extractor_architecture
    dashboard_architecture
    contributor_workflows
+   packaging
+   release_workflow
 
 Recommended Reading Order
 -------------------------
@@ -52,6 +58,8 @@ For contributors, the most useful path is usually:
 #. :doc:`extractor architecture developer notes <extractor_architecture>` — understand how extraction outputs are assembled.
 #. :doc:`dashboard architecture developer notes <dashboard_architecture>` — understand the lightweight dashboard data/plot/filter/export flow.
 #. :doc:`contributor workflows developer notes <contributor_workflows>` — use the practical recipes when adding features.
+#. :doc:`desktop packaging developer notes <packaging>` — review packaging rules when changing resource paths, GUI startup, or build scripts.
+#. :doc:`release workflow developer notes <release_workflow>` — review release cadence and artifact handling before publishing installers.
 
 The dashboard is intentionally treated as a more standalone subsystem, but a
 lightweight architecture note is included for contributors who need to work on

--- a/docs/source/developer_notes/packaging.rst
+++ b/docs/source/developer_notes/packaging.rst
@@ -53,6 +53,21 @@ GONet Wizard supports two complementary entry points.
 The desktop entry point lives in ``GONet_Wizard/desktop.py``. It exists so
 packagers can target a GUI-first executable without changing the terminal CLI.
 
+Distribution Boundary
+---------------------
+
+The macOS DMG currently distributes the GUI app only. It should not silently
+modify shell startup files, create symlinks in ``/usr/local/bin``, or add CLI
+commands to the user's ``PATH``. The user-facing expectation is:
+
+* desktop installer or DMG: double-click GUI app;
+* Python package installation: ``GONet_Wizard`` / ``gonet-wizard`` terminal commands.
+
+This boundary keeps the desktop distribution safe for non-technical users while
+preserving the full CLI for users who intentionally install the Python package.
+If a future release adds a frozen CLI artifact, document it as a separate
+artifact or an explicit opt-in installer step.
+
 Key Packaging Code Paths
 ------------------------
 

--- a/docs/source/developer_notes/packaging.rst
+++ b/docs/source/developer_notes/packaging.rst
@@ -1,0 +1,321 @@
+Desktop Packaging
+=================
+
+This page describes how GONet Wizard is prepared for frozen desktop builds.
+It is intended for maintainers working on packaging, not for end users trying
+to analyze GONet data.
+
+The user-facing application remains the same command system described in the
+:doc:`command-system developer notes <command_system>`. Packaging adds a
+native launch layer around that system so non-terminal users can double-click
+``GONet Wizard.app`` on macOS, while advanced users can continue to use the
+normal command-line interface.
+
+See also:
+
+* :doc:`UI runtime developer notes <ui_runtime>`
+* :doc:`GUI architecture developer notes <gui_architecture>`
+* :doc:`release workflow developer notes <release_workflow>`
+* :doc:`GUI launcher guide <../gui_guide/launcher>`
+* :doc:`CLI Reference <../cli_reference/index>`
+
+Packaging Goals
+---------------
+
+Desktop packaging has three goals:
+
+* Keep the GUI as a thin frontend over the existing command system.
+* Allow average users to launch GONet Wizard without opening a terminal.
+* Preserve all terminal commands for developers, automation, and advanced users.
+
+The frozen desktop app should therefore be an alternate launch path, not a
+separate implementation.
+
+Launch Paths
+------------
+
+GONet Wizard supports two complementary entry points.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Entry point
+     - Typical use
+     - Notes
+   * - ``GONet_Wizard`` / ``gonet-wizard``
+     - Terminal use, scripting, development, and debugging.
+     - Dispatches through the normal CLI parser and command handlers.
+   * - ``gonet-wizard-gui`` / desktop app bundle
+     - Double-click GUI launch for desktop users.
+     - Delegates to the same GUI command path used by ``gonet-wizard gui``.
+
+The desktop entry point lives in ``GONet_Wizard/desktop.py``. It exists so
+packagers can target a GUI-first executable without changing the terminal CLI.
+
+Key Packaging Code Paths
+------------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 42 58
+
+   * - Path
+     - Role
+   * - ``GONet_Wizard/desktop.py``
+     - GUI-first application entry point used by PyInstaller.
+   * - ``GONet_Wizard/resources.py``
+     - Resolves package-shipped resources from source, installed, and frozen layouts.
+   * - ``GONet_Wizard/paths.py``
+     - Provides user-writable cache, config, log, data, and temporary directories.
+   * - ``GONet_Wizard/gui/server.py``
+     - Creates the Flask app and exposes a lightweight ``/health`` endpoint for startup checks.
+   * - ``GONet_Wizard/gui/runtime.py``
+     - Starts the local UI server and waits for it to respond before opening the webview.
+   * - ``build_tools/pyinstaller/``
+     - PyInstaller specs, hooks, and runtime-selection rules.
+   * - ``build_tools/macos/build_dmg.sh``
+     - Creates the unsigned macOS drag-and-drop DMG after the ``.app`` build succeeds.
+
+Resource and Runtime Path Rules
+-------------------------------
+
+Frozen apps must not rely on the current working directory being the repository
+root. They also must not write cache or runtime data into the installed app
+bundle.
+
+Use these helpers instead:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Helper
+     - Use it for
+   * - ``GONet_Wizard.resources.resource_path()``
+     - Read-only package resources such as ``static/``, GUI templates, icons, logos, and small package data files.
+   * - ``GONet_Wizard.paths.user_cache_path()``
+     - Cache files produced at runtime.
+   * - ``GONet_Wizard.paths.user_config_path()``
+     - User-specific configuration files.
+   * - ``GONet_Wizard.paths.user_log_path()``
+     - Log files.
+   * - ``GONet_Wizard.paths.user_temp_path()``
+     - Temporary files that should not live beside source code or inside the app bundle.
+
+When adding new files that are shipped with the package, make sure they are
+available through package data and reachable through ``resources.py``. When
+adding files created at runtime, make sure they go through ``paths.py`` or an
+explicit user-selected output path.
+
+Startup Readiness
+-----------------
+
+The desktop GUI is served by a local Flask application and displayed through
+PyWebView. Frozen applications can start more slowly than source-mode runs, so
+opening the webview immediately can produce a blank first window.
+
+The packaging-ready startup sequence is:
+
+.. code-block:: text
+
+   start local Flask server
+        |
+        v
+   wait for /health to respond
+        |
+        v
+   open PyWebView window
+
+The health check makes first launch deterministic and should remain part of the
+packaged startup path.
+
+PyInstaller Build Files
+-----------------------
+
+The PyInstaller configuration lives under ``build_tools/pyinstaller``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 42 58
+
+   * - File
+     - Purpose
+   * - ``gonet_wizard_gui.spec``
+     - Builds the GUI-first macOS ``.app`` or Windows GUI executable.
+   * - ``gonet_wizard_cli.spec``
+     - Builds an optional console executable for CLI testing/distribution.
+   * - ``hooks/hook-GONet_Wizard.py``
+     - Collects package resources and hidden imports needed by the GONet Wizard package.
+   * - ``_runtime_selection.py``
+     - Shared include/exclude rules for Dash, Plotly, PyWebView, and other runtime dependencies.
+
+Install build dependencies with:
+
+.. code-block:: bash
+
+   pip install -e ".[build]"
+
+Build the GUI app from the repository root with:
+
+.. code-block:: bash
+
+   python -m PyInstaller build_tools/pyinstaller/gonet_wizard_gui.spec --clean --noconfirm
+
+Build the optional CLI executable with:
+
+.. code-block:: bash
+
+   python -m PyInstaller build_tools/pyinstaller/gonet_wizard_cli.spec --clean --noconfirm
+
+Dash and Plotly Assets
+----------------------
+
+Dash applications need more than Python modules. Dash component packages also
+serve JavaScript, CSS, JSON metadata, and component bundles directly from their
+package directories at runtime.
+
+For this reason, the PyInstaller rules intentionally collect non-Python package
+data broadly for Dash-related packages such as ``dash``, ``dash_daq``,
+``dash_extensions``, ``dash_core_components``, ``dash_html_components``, and
+``dash_table``.
+
+Hidden Python imports are filtered separately through
+``build_tools/pyinstaller/_runtime_selection.py``. This avoids restoring broad
+``collect_submodules(...)`` calls that would pull obvious development and test
+modules into the frozen app.
+
+.. note::
+
+   Some Dash internals have names that sound development- or notebook-specific
+   but are still imported during normal Dash startup. For example,
+   ``dash.development`` and ``dash._jupyter`` must remain importable even though
+   GONet Wizard does not expose Jupyter notebook functionality in the desktop
+   app. Keep the narrow Dash shims that Dash imports, while excluding the larger
+   notebook ecosystem such as ``IPython``, ``ipykernel``, ``jupyter``,
+   ``notebook``, and ``nbconvert``.
+
+Size Cleanup Strategy
+---------------------
+
+The packaged app bundles a scientific Python stack, so it will not be tiny.
+The cleanup goal is to avoid accidental development baggage without removing
+runtime dependencies needed by image processing, Dash apps, Plotly figures, or
+PyWebView.
+
+The current strategy is:
+
+* collect required package data broadly for Dash component packages;
+* filter hidden imports to avoid test, documentation, gallery, and notebook tooling;
+* keep runtime scientific packages unless a concrete test proves they are unused;
+* prefer a working app over aggressive size reductions.
+
+If a future frozen build fails with ``ModuleNotFoundError``, add the narrow
+runtime module to the include rules instead of reverting to unfiltered package
+collection.
+
+Unsigned macOS DMG
+------------------
+
+After the raw ``.app`` passes smoke tests, create an unsigned drag-and-drop DMG
+for local or GitHub-release testing:
+
+.. code-block:: bash
+
+   build_tools/macos/build_dmg.sh
+
+To force a fresh PyInstaller build first:
+
+.. code-block:: bash
+
+   rm -rf build dist
+   build_tools/macos/build_dmg.sh --force-pyinstaller
+
+The default output name is versioned, architecture-specific, and explicitly
+marked unsigned:
+
+.. code-block:: text
+
+   dist/GONet-Wizard-<version>-macOS-<arch>-unsigned.dmg
+
+The DMG contains:
+
+* ``GONet Wizard.app``;
+* an ``Applications`` shortcut;
+* ``README-FIRST.txt`` with notes about unsigned-build launch behavior.
+
+Unsigned DMGs are useful for internal testing and early GitHub-only
+distribution, but they are not a substitute for Developer ID signing and
+notarization.
+
+Smoke Test Checklist
+--------------------
+
+Before publishing a packaging artifact, run a clean build and test the frozen
+app, not only the source checkout.
+
+Recommended local test:
+
+.. code-block:: bash
+
+   pytest
+   rm -rf build dist
+   build_tools/macos/build_dmg.sh --force-pyinstaller
+
+Then install or open the generated app and check:
+
+* the main launcher opens from Finder or from the installed app location;
+* the launcher CSS, JavaScript, logo, and templates load correctly;
+* the ``show`` form opens and can render an image preview;
+* the ``extract`` form opens and can launch the interactive Dash extraction UI;
+* the ``dashboard`` command opens the dashboard and loads Dash component assets;
+* the app can be closed and reopened without a blank first window;
+* runtime cache/log/temp files are not created in the repository root or inside the app bundle.
+
+Troubleshooting Frozen Builds
+-----------------------------
+
+Blank window on first launch
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This usually means the webview opened before the local Flask server was ready.
+Confirm that the GUI runtime starts the server, waits for ``/health``, and only
+then opens the webview.
+
+Missing Dash asset
+~~~~~~~~~~~~~~~~~~
+
+Errors such as missing ``package-info.json`` or ``*.min.js`` files usually mean
+that a Dash component package is missing package data in the PyInstaller rules.
+Add package data collection for the component package rather than hard-coding a
+single file.
+
+Missing Python module
+~~~~~~~~~~~~~~~~~~~~~
+
+Errors such as ``ModuleNotFoundError`` after size cleanup usually mean that the
+module was excluded too aggressively. Add the narrow module or package to the
+runtime selection rules and rebuild from a clean ``build`` and ``dist``.
+
+macOS Gatekeeper blocks unsigned app
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Unsigned builds may be blocked the first time they are opened on another Mac.
+For internal testing, users can usually control-click the app and choose
+``Open``, or allow it from ``System Settings > Privacy & Security`` after the
+first blocked launch. For wider distribution, plan for signing and notarization.
+
+Future Windows Packaging
+------------------------
+
+Windows packaging should follow the same architecture:
+
+* keep the Python package and command system unchanged;
+* build a GUI executable from the desktop entry point;
+* keep the CLI executable available for advanced users;
+* wrap the frozen app in a Windows installer rather than committing generated files to git;
+* publish installers as GitHub Release assets.
+
+The likely Windows path is a PyInstaller build followed by an Inno Setup
+installer. Windows-specific work should be validated on a real Windows machine
+or Windows runner before publishing user-facing artifacts.

--- a/docs/source/developer_notes/release_workflow.rst
+++ b/docs/source/developer_notes/release_workflow.rst
@@ -1,0 +1,236 @@
+Release Workflow
+================
+
+This page describes the recommended distribution workflow for packaged GONet
+Wizard desktop builds. It focuses on maintainability: source code, build
+configuration, and release automation belong in git, while generated installers
+belong in GitHub Releases.
+
+For the lower-level PyInstaller and DMG mechanics, see
+:doc:`desktop packaging developer notes <packaging>`.
+
+Release Artifacts Are Not Source Files
+--------------------------------------
+
+Generated files such as ``.dmg`` and ``.exe`` installers should not be committed
+to the repository.
+
+Keep these files in git:
+
+* source code;
+* tests;
+* documentation;
+* PyInstaller specs;
+* DMG and future Windows installer scripts;
+* GitHub Actions workflows.
+
+Publish these files outside git history:
+
+* macOS DMGs;
+* Windows installers;
+* checksums;
+* other large generated release artifacts.
+
+GitHub Releases are the intended distribution location for user-facing
+installers. GitHub Actions artifacts are useful for short-lived test builds,
+but they should not be treated as permanent releases.
+
+Recommended Build Cadence
+-------------------------
+
+Desktop installers are large and slow to build. They should not be generated on
+every commit.
+
+Use this cadence instead:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 40 30
+
+   * - When
+     - What to run
+     - Purpose
+   * - Normal code change
+     - Unit tests and documentation checks.
+     - Keep development fast.
+   * - Packaging-related change
+     - Local frozen-app smoke test and optional manual GitHub Actions build.
+     - Validate packaging logic before merging.
+   * - Release candidate
+     - Manual GitHub Actions build.
+     - Produce a downloadable candidate without publishing a release.
+   * - Versioned release
+     - Push a ``v*`` tag.
+     - Build release artifacts and attach them to a draft GitHub Release.
+
+Local Packaging Test
+--------------------
+
+Before asking GitHub Actions to build a release candidate, run the local smoke
+test on the relevant operating system.
+
+For macOS:
+
+.. code-block:: bash
+
+   pytest
+   rm -rf build dist
+   build_tools/macos/build_dmg.sh --force-pyinstaller
+
+Then open the generated DMG, drag ``GONet Wizard.app`` to ``Applications`` or a
+temporary test folder, and run the smoke test from
+:doc:`desktop packaging developer notes <packaging>`.
+
+Manual GitHub Actions Build
+---------------------------
+
+The macOS workflow is designed to be runnable manually from the GitHub Actions
+tab. A manual run should:
+
+* build the unsigned macOS DMG on a GitHub-hosted macOS runner;
+* generate a SHA-256 checksum file;
+* upload a short-lived Actions artifact for testing.
+
+Use manual workflow runs for candidate builds that should be tested before a
+tagged release exists.
+
+Tagged Release Build
+--------------------
+
+When a version is ready for distribution, create and push a version tag:
+
+.. code-block:: bash
+
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+
+The packaging workflow should build the release artifact and upload it to a
+draft GitHub Release for that tag. Keeping the release as a draft provides a
+final review step before users see the installer.
+
+A typical release should contain:
+
+.. code-block:: text
+
+   GONet-Wizard-X.Y.Z-macOS-arm64-unsigned.dmg
+   SHA256SUMS.txt
+
+When Windows packaging is added, the same release can also contain the Windows
+installer:
+
+.. code-block:: text
+
+   GONet-Wizard-X.Y.Z-Windows-x64-Setup.exe
+
+Versioned Artifact Names
+------------------------
+
+Release artifacts should include the package version, platform, architecture,
+and signing status in the filename.
+
+For example:
+
+.. code-block:: text
+
+   GONet-Wizard-0.3.0-macOS-arm64-unsigned.dmg
+   GONet-Wizard-0.3.0-Windows-x64-unsigned-Setup.exe
+
+This makes downloaded files self-describing and avoids ambiguity when several
+release candidates are tested side by side.
+
+The macOS DMG script resolves the version from installed package metadata when
+possible. For test builds, the version can be overridden manually:
+
+.. code-block:: bash
+
+   build_tools/macos/build_dmg.sh --version 0.3.0-rc1
+
+Checksums
+---------
+
+Release workflows should produce a checksum file next to the installer.
+
+For macOS and Linux shell environments:
+
+.. code-block:: bash
+
+   shasum -a 256 dist/GONet-Wizard-*.dmg > dist/SHA256SUMS.txt
+
+Checksums help users and maintainers verify that downloaded files match the
+published artifact.
+
+GitHub-Only Distribution
+------------------------
+
+For the current project stage, GitHub-only distribution is appropriate:
+
+* source code stays in the repository;
+* test builds are uploaded as temporary Actions artifacts;
+* official installers are uploaded as GitHub Release assets;
+* installers are not committed to git and are not distributed through the Apple App Store or Microsoft Store.
+
+This keeps distribution simple while still allowing repeatable builds and a
+clear release history.
+
+macOS Signing Status
+--------------------
+
+The current macOS DMG path is explicitly unsigned. Unsigned builds are suitable
+for early internal testing and GitHub-only prototypes, but users should expect
+macOS Gatekeeper warnings.
+
+Future public-facing macOS releases should consider:
+
+* Developer ID signing;
+* hardened runtime settings;
+* notarization;
+* documenting the difference between signed and unsigned release files.
+
+The filename should continue to include the signing status until signed and
+notarized releases are the default.
+
+macOS Architecture Strategy
+---------------------------
+
+The first validated macOS path targets Apple Silicon. Intel macOS builds can be
+added later as a separate build target if there is user demand.
+
+If both architectures are released, publish separate artifacts with explicit
+architecture names, for example:
+
+.. code-block:: text
+
+   GONet-Wizard-0.3.0-macOS-arm64-unsigned.dmg
+   GONet-Wizard-0.3.0-macOS-x86_64-unsigned.dmg
+
+Do not label either artifact as universal unless the build process actually
+produces and tests a universal binary.
+
+Windows Release Path
+--------------------
+
+Windows packaging should follow the same release model:
+
+* validate the frozen executable on Windows;
+* wrap it with an installer script, likely Inno Setup;
+* account for the WebView2 runtime expectation;
+* upload the installer to GitHub Releases;
+* avoid committing generated ``.exe`` files to git.
+
+A Windows GitHub Actions workflow can be added after the Windows PyInstaller and
+installer path has been validated on a Windows machine or Windows runner.
+
+Release Checklist
+-----------------
+
+Before publishing a release:
+
+#. Confirm the version in package metadata.
+#. Run the full test suite.
+#. Build the platform installer from a clean checkout or clean build directory.
+#. Install the generated artifact like a user would.
+#. Smoke test launcher, ``show``, ``extract``, and ``dashboard`` from the installed app.
+#. Generate checksums.
+#. Upload artifacts to a draft GitHub Release.
+#. Review release notes, filenames, version numbers, architecture labels, and signing labels.
+#. Publish the GitHub Release only after the artifact has been tested.

--- a/docs/source/developer_notes/release_workflow.rst
+++ b/docs/source/developer_notes/release_workflow.rst
@@ -172,6 +172,21 @@ For the current project stage, GitHub-only distribution is appropriate:
 This keeps distribution simple while still allowing repeatable builds and a
 clear release history.
 
+User-Facing Install Paths
+-------------------------
+
+Release notes and README instructions should keep the installation paths clear:
+
+* the desktop installer or DMG is for GUI users and does not install CLI
+  commands;
+* the Python package installation is for CLI users, scripted workflows, and
+  developers.
+
+A release can contain the desktop DMG without changing the command-line
+installation story. If a future release publishes a frozen CLI executable, ship
+it as a clearly named separate artifact and document how users should add it to
+``PATH``.
+
 macOS Signing Status
 --------------------
 

--- a/docs/source/gui_guide/index.rst
+++ b/docs/source/gui_guide/index.rst
@@ -11,6 +11,13 @@ For terminal usage, see :doc:`CLI Reference <../cli_reference/index>`. For imple
 details, see :doc:`GUI architecture developer notes <../developer_notes/gui_architecture>` and
 :doc:`UI runtime developer notes <../developer_notes/ui_runtime>`.
 
+.. note::
+
+   The downloadable desktop app is intended for GUI use. It opens the graphical
+   launcher without requiring a terminal, but it does not install the
+   ``GONet_Wizard`` or ``gonet-wizard`` command-line tools. Install the Python
+   package if you also want terminal commands.
+
 GUI Pages
 ---------
 

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,6 +10,52 @@ This guide walks you through setting up the environment and installing the packa
 
 ----
 
+Choosing an installation path
+-----------------------------
+
+GONet Wizard can be used as a double-click desktop application, as a Python
+command-line package, or both. Choose the installation path that matches how you
+plan to work.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 36 36
+
+   * - Installation path
+     - Best for
+     - What it provides
+   * - Desktop installer or DMG
+     - Users who want to open the graphical interface without using a terminal.
+     - A double-click ``GONet Wizard`` app that opens the GUI launcher. It does
+       not add ``GONet_Wizard`` or ``gonet-wizard`` commands to your shell
+       ``PATH``.
+   * - Python package installation with ``pip`` or ``pipx``
+     - CLI users, scripted workflows, developers, and users who want both the
+       terminal commands and the GUI command.
+     - The ``GONet_Wizard`` and ``gonet-wizard`` command-line entry points. The
+       GUI can also be started from the terminal with ``GONet_Wizard gui``.
+
+.. important::
+
+   Installing the desktop app is not the same as installing the Python command
+   line package. The desktop app is meant to hide the terminal for GUI users. If
+   you want terminal commands, install the Python package as described below.
+
+Desktop app installation
+------------------------
+
+Desktop installers are distributed through the GitHub Releases page when a
+packaged build is available. On macOS, the current packaging path produces a
+drag-and-drop DMG containing ``GONet Wizard.app``. After dragging the app to
+``Applications``, launch it by double-clicking the icon.
+
+The desktop app opens the GUI launcher. It does not install command-line entry
+points, modify shell startup files, or add anything to ``PATH``.
+
+Early macOS DMGs may be unsigned. If macOS blocks the app on first launch, see
+the release notes and the ``README-FIRST.txt`` file included in the DMG for the
+expected Gatekeeper behavior.
+
 Creating a Python environment
 -----------------------------
 

--- a/docs/source/user_guide/gui_vs_cli.rst
+++ b/docs/source/user_guide/gui_vs_cli.rst
@@ -21,6 +21,32 @@ This means that the GUI is not a simplified fork of the code and the CLI is not
 a separate backend. Both interfaces call into the same command definitions,
 loaders, file models, extraction utilities, plotting logic, and output writers.
 
+Installation paths
+------------------
+
+The GUI and CLI share code, but they can be installed through different user
+paths. This distinction is important.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 35 35
+
+   * - Installation path
+     - What the user launches
+     - CLI availability
+   * - Desktop installer or DMG
+     - A double-click ``GONet Wizard`` app.
+     - Does not install ``GONet_Wizard`` or ``gonet-wizard`` shell commands.
+   * - Python package installation
+     - Terminal commands such as ``GONet_Wizard show`` and
+       ``GONet_Wizard gui``.
+     - Installs the public CLI entry points, assuming the Python script
+       directory is on ``PATH``.
+
+Use the desktop installer when you want to avoid the terminal entirely. Use the
+Python package installation when you want command-line tools, scripting, or a
+development environment. See :doc:`../installation` for installation details.
+
 When to use the GUI
 -------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "ruff",
 ]
 docs = ["sphinx>=7.0", "sphinx-autodoc-typehints", "sphinx-rtd-theme", "myst-parser"]
+build = ["pyinstaller>=6.0"]
 
 [project.urls]
 Homepage = "https://github.com/gterreran/GONet_Wizard"
@@ -52,9 +53,20 @@ Issues = "https://github.com/gterreran/GONet_Wizard/issues"
 
 [project.scripts]
 GONet_Wizard = "GONet_Wizard.__main__:main"
+gonet-wizard = "GONet_Wizard.__main__:main"
+
+[project.gui-scripts]
+GONet_Wizard_GUI = "GONet_Wizard.desktop:main"
+gonet-wizard-gui = "GONet_Wizard.desktop:main"
 
 [tool.setuptools]
 include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["GONet_Wizard*"]
+exclude = ["build_tools*", "docs*", "tests*"]
+namespaces = false
 
 [tool.setuptools.package-data]
 GONet_Wizard = [

--- a/tests/test_packaging_paths.py
+++ b/tests/test_packaging_paths.py
@@ -1,0 +1,173 @@
+from pathlib import Path
+
+
+def test_desktop_entrypoint_delegates_to_gui_command(monkeypatch):
+    import types
+    import sys
+
+    from GONet_Wizard import desktop
+
+    called = {}
+
+    def fake_cli_main(argv=None):
+        called["argv"] = argv
+
+    fake_cli = types.SimpleNamespace(main=fake_cli_main)
+    monkeypatch.setitem(sys.modules, "GONet_Wizard.cli", fake_cli)
+
+    desktop.main(["--port", "5051"])
+
+    assert called == {"argv": ["gui", "--port", "5051"]}
+
+
+def test_resource_helpers_find_static_and_templates():
+    from GONet_Wizard.resources import resource_path, static_dir, template_dir
+
+    assert resource_path().is_dir()
+    assert static_dir("css", "style.css", must_exist=True).is_file()
+    assert template_dir("index.html", must_exist=True).is_file()
+
+
+def test_resource_path_supports_pyinstaller_package_layout(monkeypatch, tmp_path: Path):
+    from GONet_Wizard import resources
+
+    bundled = tmp_path / "_MEIPASS" / "GONet_Wizard" / "static" / "css"
+    bundled.mkdir(parents=True)
+    css = bundled / "style.css"
+    css.write_text("body {}", encoding="utf-8")
+
+    monkeypatch.setattr(resources.sys, "_MEIPASS", str(tmp_path / "_MEIPASS"), raising=False)
+
+    assert resources.static_dir("css", "style.css") == css
+
+
+def test_user_paths_can_be_redirected_with_home_override(monkeypatch, tmp_path: Path):
+    from GONet_Wizard import paths
+
+    monkeypatch.setenv(paths.ENV_HOME, str(tmp_path / "gonet-home"))
+
+    got = paths.cache_dir("dash", "extract_gui")
+
+    assert got == tmp_path / "gonet-home" / "cache" / "dash" / "extract_gui"
+    assert got.is_dir()
+
+
+def test_resource_path_supports_pyinstaller_onedir_layout(monkeypatch, tmp_path: Path):
+    from GONet_Wizard import resources
+
+    exe_dir = tmp_path / "dist" / "GONet Wizard"
+    bundled = exe_dir / "GONet_Wizard" / "gui" / "templates"
+    bundled.mkdir(parents=True)
+    template = bundled / "index.html"
+    template.write_text("<html></html>", encoding="utf-8")
+
+    monkeypatch.setattr(resources.sys, "frozen", True, raising=False)
+    monkeypatch.delattr(resources.sys, "_MEIPASS", raising=False)
+    monkeypatch.setattr(resources.sys, "executable", str(exe_dir / "GONet Wizard"), raising=False)
+
+    assert resources.template_dir("index.html") == template
+
+
+def test_resource_path_supports_macos_app_resources_layout(monkeypatch, tmp_path: Path):
+    from GONet_Wizard import resources
+
+    app_root = tmp_path / "GONet Wizard.app" / "Contents"
+    macos_dir = app_root / "MacOS"
+    resources_dir = app_root / "Resources" / "GONet_Wizard" / "static" / "css"
+    macos_dir.mkdir(parents=True)
+    resources_dir.mkdir(parents=True)
+    css = resources_dir / "style.css"
+    css.write_text("body {}", encoding="utf-8")
+
+    monkeypatch.setattr(resources.sys, "frozen", True, raising=False)
+    monkeypatch.delattr(resources.sys, "_MEIPASS", raising=False)
+    monkeypatch.setattr(resources.sys, "executable", str(macos_dir / "GONet Wizard"), raising=False)
+
+    assert resources.static_dir("css", "style.css") == css
+
+
+def test_pyinstaller_build_scaffolding_files_exist():
+    root = Path(__file__).resolve().parents[1]
+    build_root = root / "build_tools" / "pyinstaller"
+
+    assert (build_root / "README.md").is_file()
+    assert (build_root / "gonet_wizard_gui.spec").is_file()
+    assert (build_root / "gonet_wizard_cli.spec").is_file()
+    assert (build_root / "hooks" / "hook-GONet_Wizard.py").is_file()
+    assert (build_root / "_runtime_selection.py").is_file()
+
+
+def test_pyinstaller_scaffolding_collects_dash_component_package_data():
+    root = Path(__file__).resolve().parents[1]
+    build_root = root / "build_tools" / "pyinstaller"
+
+    gui_spec = (build_root / "gonet_wizard_gui.spec").read_text(encoding="utf-8")
+    cli_spec = (build_root / "gonet_wizard_cli.spec").read_text(encoding="utf-8")
+    hook = (build_root / "hooks" / "hook-GONet_Wizard.py").read_text(encoding="utf-8")
+    shared = (build_root / "_runtime_selection.py").read_text(encoding="utf-8")
+
+    for text in (gui_spec, cli_spec, hook):
+        assert "collect_dash_component_datas" in text
+
+    assert "DASH_COMPONENT_PACKAGES" in shared
+    assert '"dash_daq"' in shared
+    assert '"dash_extensions"' in shared
+    assert "include_py_files=False" in shared
+
+
+def test_pyinstaller_scaffolding_filters_development_modules_from_runtime_imports():
+    root = Path(__file__).resolve().parents[1]
+    build_root = root / "build_tools" / "pyinstaller"
+
+    gui_spec = (build_root / "gonet_wizard_gui.spec").read_text(encoding="utf-8")
+    cli_spec = (build_root / "gonet_wizard_cli.spec").read_text(encoding="utf-8")
+    hook = (build_root / "hooks" / "hook-GONet_Wizard.py").read_text(encoding="utf-8")
+    shared = (build_root / "_runtime_selection.py").read_text(encoding="utf-8")
+
+    for text in (gui_spec, cli_spec):
+        assert "collect_runtime_hiddenimports" in text
+        assert "excludes=EXCLUDES" in text
+
+    assert "excludedimports = EXCLUDES" in hook
+    assert "EXCLUDED_MODULE_PREFIXES" in shared
+    for module_name in [
+        '"dash.testing"',
+        '"dash.development.build_process"',
+        '"plotly.io._sg_scraper"',
+        '"pytest"',
+        '"sphinx"',
+    ]:
+        assert module_name in shared
+
+
+def test_pyinstaller_scaffolding_keeps_dash_runtime_development_package():
+    root = Path(__file__).resolve().parents[1]
+    shared = (root / "build_tools" / "pyinstaller" / "_runtime_selection.py").read_text(
+        encoding="utf-8"
+    )
+
+    assert '"dash.development",' not in shared
+    assert '"dash.development.build_process"' in shared
+
+
+def test_macos_dmg_build_scaffolding_files_exist():
+    root = Path(__file__).resolve().parents[1]
+    macos_root = root / "build_tools" / "macos"
+
+    assert (macos_root / "README.md").is_file()
+    assert (macos_root / "build_dmg.sh").is_file()
+
+
+def test_macos_dmg_build_script_documents_unsigned_release_flow():
+    root = Path(__file__).resolve().parents[1]
+    script = (root / "build_tools" / "macos" / "build_dmg.sh").read_text(
+        encoding="utf-8"
+    )
+
+    assert "hdiutil create" in script
+    assert "GONet-Wizard-${SAFE_VERSION}-macOS-${ARCH_NAME}-unsigned.dmg" in script
+    assert "--version VERSION" in script
+    assert "ln -s /Applications" in script
+    assert "README-FIRST.txt" in script
+    assert "--skip-pyinstaller" in script
+    assert "--force-pyinstaller" in script

--- a/tests/test_ui_server_readiness.py
+++ b/tests/test_ui_server_readiness.py
@@ -1,0 +1,63 @@
+"""Tests for unified UI server health/readiness helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_create_app_exposes_health_endpoint():
+    server = pytest.importorskip("GONet_Wizard.ui.server")
+
+    app = server.create_app()
+    client = app.test_client()
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == "ok"
+
+
+def test_wait_for_server_retries_until_health_endpoint_responds(monkeypatch):
+    server = pytest.importorskip("GONet_Wizard.ui.server")
+    calls = {"count": 0}
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self):
+            return b"ok"
+
+    def fake_urlopen(url, timeout):
+        calls["count"] += 1
+        if calls["count"] < 3:
+            raise OSError("not ready yet")
+        return FakeResponse()
+
+    monkeypatch.setattr(server.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr(server.time, "sleep", lambda _: None)
+
+    server.wait_for_server("127.0.0.1", 5050, timeout=1.0, poll_interval=0.01)
+
+    assert calls["count"] == 3
+
+
+def test_dash_runner_surfaces_background_startup_errors():
+    dash_runner = pytest.importorskip("GONet_Wizard.ui.dash_runner")
+
+    errors = dash_runner.Queue()
+    errors.put(RuntimeError("synthetic startup failure"))
+
+    with pytest.raises(RuntimeError, match="synthetic startup failure"):
+        dash_runner.wait_for_port(
+            "127.0.0.1",
+            9,
+            timeout=1.0,
+            startup_errors=errors,
+            app_key="test-dash-app",
+        )


### PR DESCRIPTION
## Summary

This PR adds the first full desktop packaging workflow for GONet Wizard, focused on macOS.

The goal is to let non-technical users install and launch the GUI without using the terminal, while preserving the existing Python/CLI workflow for power users and developers.

This branch adds:

* a GUI-specific desktop entry point;
* packaging-safe resource and runtime path helpers;
* PyInstaller build scaffolding for the GUI and CLI;
* macOS `.app` and unsigned DMG generation;
* a GitHub Actions workflow for building macOS DMG artifacts;
* documentation explaining the difference between desktop GUI installation and Python/CLI installation.

## Main changes

### Desktop entry point

Adds `GONet_Wizard/desktop.py`, which launches the existing GUI directly. This provides a clean target for PyInstaller and future desktop installers without changing the existing CLI behavior.

### Resource and runtime path handling

Adds centralized helpers for:

* locating bundled resources in source, editable install, and frozen-app contexts;
* resolving static files, templates, icons, logos, and package data;
* writing runtime files to user-writable locations instead of assuming the repository or install directory is writable.

This is needed for frozen desktop apps, where package/resource paths differ from normal source-mode execution.

### GUI startup readiness

Updates the GUI server launch sequence so the webview waits for the local Flask server to become responsive before opening the window. This fixes an intermittent blank-window issue observed in the first PyInstaller builds.

### PyInstaller packaging

Adds PyInstaller specs, hooks, and shared runtime-selection helpers under `build_tools/`.

The packaging configuration includes the Dash/Plotly component metadata and frontend assets needed by the extract GUI and dashboard. It also filters out obvious non-runtime modules where safe, while keeping required Dash runtime internals.

### macOS DMG packaging

Adds `build_tools/macos/build_dmg.sh`, which creates an unsigned drag-and-drop DMG containing:

* `GONet Wizard.app`
* an Applications shortcut
* a README explaining the unsigned/Gatekeeper status

The generated artifact is versioned and architecture-specific.

### GitHub Actions packaging workflow

Adds `.github/workflows/package-macos.yml`.

The workflow can:

* build a macOS unsigned DMG manually through `workflow_dispatch`;
* build automatically when a `v*` tag is pushed;
* upload short-lived GitHub Actions artifacts;
* attach DMG and checksum files to a draft GitHub Release for tagged builds.

### Documentation

Adds and updates documentation to explain:

* desktop packaging architecture;
* release workflow;
* local DMG testing;
* GitHub Actions artifact vs GitHub Release asset usage;
* the distinction between GUI desktop installation and Python/CLI installation.

Importantly, the docs and README now explicitly state that the downloadable desktop app is for launching the GUI and does **not** install CLI commands into the user’s shell `PATH`. Users who want `GONet_Wizard` / `gonet-wizard` from the terminal should install the Python package with `pip` or `pipx`.

## Validation

Tested locally on macOS:

* `pytest`
* Sphinx docs build
* PyInstaller GUI build
* local `.app` launch
* local unsigned DMG creation
* launch from the DMG-installed app
* GUI main window
* show command
* extract GUI
* dashboard
* repeated open/close launches

Also tested through GitHub Actions:

* macOS DMG workflow completed successfully
* short-lived artifact uploaded
* downloaded GitHub-built DMG worked locally

## Notes

This PR intentionally does **not** add Windows packaging yet. Windows packaging will be handled separately because it requires testing on a Windows machine and will likely need its own PyInstaller/Inno Setup/WebView2-specific fixes.

This PR also does not add code signing or notarization. The macOS DMG is currently unsigned, so users may see normal Gatekeeper warnings.
