### PR TITLE
Add Windows GUI installer and release workflow

### DIFF
--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -1,0 +1,114 @@
+name: Build Windows Installer
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Optional version label for the installer name. Leave blank to use package/git metadata."
+        required: false
+        default: ""
+      force_pyinstaller:
+        description: "Force a fresh PyInstaller build before creating the installer."
+        required: false
+        type: boolean
+        default: true
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  windows-installer:
+    name: Windows unsigned installer
+    runs-on: windows-2025
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+
+      - name: Install package and build dependencies
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[build]"
+
+      - name: Install Inno Setup
+        shell: pwsh
+        run: |
+          choco install innosetup --yes --no-progress
+          $candidates = @(
+            "C:\Program Files (x86)\Inno Setup 6\ISCC.exe",
+            "C:\Program Files\Inno Setup 6\ISCC.exe"
+          )
+          $compiler = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+          if (-not $compiler) {
+            $compiler = (Get-Command ISCC.exe -ErrorAction SilentlyContinue).Source
+          }
+          if (-not $compiler) {
+            throw "Could not locate ISCC.exe after installing Inno Setup."
+          }
+          "INNO_SETUP_COMPILER=$compiler" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          Write-Host "Using Inno Setup compiler: $compiler"
+
+      - name: Build unsigned Windows installer
+        shell: pwsh
+        env:
+          REQUESTED_VERSION: ${{ inputs.version || '' }}
+          FORCE_PYINSTALLER: ${{ inputs.force_pyinstaller != false }}
+        run: |
+          $buildArgs = @()
+
+          if ($env:FORCE_PYINSTALLER -eq "true") {
+            $buildArgs += "-ForcePyInstaller"
+          }
+          else {
+            $buildArgs += "-SkipPyInstaller"
+          }
+
+          if ($env:REQUESTED_VERSION) {
+            $buildArgs += "-Version"
+            $buildArgs += $env:REQUESTED_VERSION
+          }
+
+          if ($env:INNO_SETUP_COMPILER) {
+            $buildArgs += "-InnoSetupCompiler"
+            $buildArgs += $env:INNO_SETUP_COMPILER
+          }
+
+          powershell -ExecutionPolicy Bypass -File build_tools\windows\build_installer.ps1 @buildArgs
+
+      - name: Upload short-lived build artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: gonet-wizard-windows-installer
+          path: |
+            dist/*Windows-x64-unsigned-Setup.exe
+            dist/SHA256SUMS-Windows.txt
+          retention-days: 7
+
+      - name: Upload assets to tagged GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          gh release view $env:TAG_NAME *> $null
+          if ($LASTEXITCODE -ne 0) {
+            gh release create $env:TAG_NAME `
+              --draft `
+              --title "GONet Wizard $env:TAG_NAME" `
+              --notes "Draft release created automatically from $env:TAG_NAME."
+          }
+
+          gh release upload $env:TAG_NAME dist/*Windows-x64-unsigned-Setup.exe dist/SHA256SUMS-Windows.txt --clobber

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -4,19 +4,15 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Optional version label for the installer, e.g. 0.3.0-test"
+        description: "Optional version label for the installer name. Leave blank to use package/git metadata."
         required: false
         default: ""
-        type: string
       force_pyinstaller:
-        description: "Force a fresh PyInstaller build before creating the installer"
-        required: true
-        default: true
+        description: "Force a fresh PyInstaller build before creating the installer."
+        required: false
         type: boolean
-
+        default: true
   push:
-    branches:
-      - "windows-installer"
     tags:
       - "v*"
 

--- a/.github/workflows/package-windows.yml
+++ b/.github/workflows/package-windows.yml
@@ -4,15 +4,19 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Optional version label for the installer name. Leave blank to use package/git metadata."
+        description: "Optional version label for the installer, e.g. 0.3.0-test"
         required: false
         default: ""
+        type: string
       force_pyinstaller:
-        description: "Force a fresh PyInstaller build before creating the installer."
-        required: false
-        type: boolean
+        description: "Force a fresh PyInstaller build before creating the installer"
+        required: true
         default: true
+        type: boolean
+
   push:
+    branches:
+      - "windows-installer"
     tags:
       - "v*"
 

--- a/README.rst
+++ b/README.rst
@@ -35,8 +35,10 @@ GONet Wizard has two installation paths, depending on how you want to use it.
 Downloadable desktop installers from the
 `GitHub Releases page <https://github.com/gterreran/GONet_Wizard/releases>`_
 are intended for users who want to launch GONet Wizard by double-clicking the
-application icon. The desktop app opens the graphical launcher and does not
-install the command-line tools into your shell ``PATH``.
+application icon. On macOS this is distributed as a DMG; on Windows this is
+distributed as a Setup.exe installer when a Windows build is available. The
+desktop app opens the graphical launcher and does not install the command-line
+tools into your shell ``PATH``.
 
 **Python package for CLI users**
 

--- a/build_tools/windows/README.md
+++ b/build_tools/windows/README.md
@@ -96,6 +96,28 @@ After building `Setup.exe`, test like a user would:
 6. Uninstall from Windows Settings.
 7. Reinstall and repeat a basic launch test.
 
+
+## GitHub Actions build
+
+After the local installer path has been validated on Windows, the same build can
+be run from GitHub Actions with the ``package-windows.yml`` workflow. The
+workflow installs Python 3.10, installs the package with the ``build`` extra,
+installs Inno Setup, runs this build script, uploads a short-lived Actions
+artifact, and uploads release assets when a ``v*`` tag is pushed.
+
+For a manual test build from the GitHub CLI, after the workflow exists on the
+selected branch:
+
+```powershell
+gh workflow run package-windows.yml `
+  --ref windows-installer `
+  -f version=0.0.0-windows-test `
+  -f force_pyinstaller=true
+```
+
+For tagged releases, the workflow creates or updates a draft GitHub Release and
+uploads both the unsigned Windows installer and ``SHA256SUMS-Windows.txt``.
+
 ## WebView2 note
 
 The Windows GUI uses PyWebView. On modern Windows machines, the Microsoft Edge

--- a/build_tools/windows/README.md
+++ b/build_tools/windows/README.md
@@ -1,0 +1,104 @@
+# Windows desktop installer
+
+This folder contains the local Windows installer tooling for GONet Wizard.
+
+The Windows installer is intentionally GUI-first. It installs the frozen
+`GONet Wizard.exe` desktop application and creates Start Menu shortcuts. It does
+not add `GONet_Wizard` or `gonet-wizard` command-line entry points to `PATH`.
+Users who want the CLI should install the Python package with `pip` or `pipx`.
+
+## Prerequisites
+
+Build and test on Windows. PyInstaller does not cross-compile Windows apps from
+macOS or Linux.
+
+Recommended local environment:
+
+```powershell
+py -3.10 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -e ".[dev,build]"
+pytest
+```
+
+Install Inno Setup 6 and make sure `ISCC.exe` is available either on `PATH` or
+in one of the standard install locations:
+
+- `C:\Program Files (x86)\Inno Setup 6\ISCC.exe`
+- `C:\Program Files\Inno Setup 6\ISCC.exe`
+
+If it is installed elsewhere, pass `-InnoSetupCompiler` to the build script.
+
+## Build the frozen app
+
+From the repository root:
+
+```powershell
+python -m PyInstaller build_tools\pyinstaller\gonet_wizard_gui.spec --clean --noconfirm
+```
+
+Then smoke test the raw frozen app before building an installer:
+
+```powershell
+.\dist\"GONet Wizard"\"GONet Wizard.exe"
+```
+
+Check the launcher, `show`, `extract`, and `dashboard`.
+
+## Build the installer
+
+To force a fresh PyInstaller build and then create the installer:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File build_tools\windows\build_installer.ps1 -ForcePyInstaller
+```
+
+To reuse an existing `dist\GONet Wizard\` folder:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File build_tools\windows\build_installer.ps1 -SkipPyInstaller
+```
+
+The default output is:
+
+```text
+dist\GONet-Wizard-<version>-Windows-x64-unsigned-Setup.exe
+dist\SHA256SUMS-Windows.txt
+```
+
+Use an explicit test version with:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File build_tools\windows\build_installer.ps1 -Version 0.0.0-windows-test -ForcePyInstaller
+```
+
+## Installer behavior
+
+The first installer path is intentionally simple:
+
+- installs per-user under `%LOCALAPPDATA%\Programs\GONet Wizard`;
+- creates a Start Menu shortcut;
+- offers an optional Desktop shortcut;
+- supports normal Windows uninstall;
+- does not require administrator privileges;
+- does not modify the user's `PATH`.
+
+## Local smoke test
+
+After building `Setup.exe`, test like a user would:
+
+1. Run the installer.
+2. Launch GONet Wizard from the Start Menu.
+3. Launch it from the Desktop shortcut if selected.
+4. Check the launcher, `show`, `extract`, and `dashboard`.
+5. Close and reopen the app.
+6. Uninstall from Windows Settings.
+7. Reinstall and repeat a basic launch test.
+
+## WebView2 note
+
+The Windows GUI uses PyWebView. On modern Windows machines, the Microsoft Edge
+WebView2 Runtime is usually already present. If users report that the desktop
+window cannot open, check whether WebView2 is installed before changing the
+PyInstaller configuration.

--- a/build_tools/windows/build_installer.ps1
+++ b/build_tools/windows/build_installer.ps1
@@ -1,0 +1,239 @@
+<#
+Build the local Windows installer for GONet Wizard.
+
+This script wraps two steps:
+  1. Optionally build the PyInstaller one-dir GUI app.
+  2. Run Inno Setup to create a user-local Setup.exe installer.
+
+Run from the repository root, or from any location inside the repository:
+
+  powershell -ExecutionPolicy Bypass -File build_tools\windows\build_installer.ps1 -ForcePyInstaller
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$ForcePyInstaller,
+    [switch]$SkipPyInstaller,
+    [string]$Version = "",
+    [string]$InnoSetupCompiler = "",
+    [string]$SourceDir = "",
+    [string]$OutputDir = "",
+    [switch]$NoChecksum
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Write-Step {
+    param([string]$Message)
+    Write-Host "`n==> $Message" -ForegroundColor Cyan
+}
+
+function Resolve-RepositoryRoot {
+    $scriptDir = Split-Path -Parent $PSCommandPath
+    return (Resolve-Path (Join-Path $scriptDir "..\..")).Path
+}
+
+function Resolve-PythonVersion {
+    param([string]$RepositoryRoot)
+
+    if ($Version.Trim()) {
+        return $Version.Trim()
+    }
+
+    $gitVersion = (& git -C $RepositoryRoot describe --tags --always --dirty 2>$null)
+    if ($LASTEXITCODE -eq 0 -and $gitVersion) {
+        $gitVersion = ($gitVersion | Select-Object -First 1).ToString().Trim()
+        if ($gitVersion) {
+            return ($gitVersion -replace '^v', '')
+        }
+    }
+
+    try {
+        $detected = (& python -c "import importlib.metadata as m; print(m.version('GONet_Wizard'))" 2>$null)
+        if ($LASTEXITCODE -eq 0 -and $detected) {
+            $detected = ($detected | Select-Object -First 1).ToString().Trim()
+            if ($detected) {
+                return $detected
+            }
+        }
+    }
+    catch {
+        # Fall through to the local fallback below.
+    }
+
+    return "0.0.0-windows-local"
+}
+
+function Convert-ToSafeFileVersion {
+    param([string]$RawVersion)
+    return ($RawVersion -replace '[^0-9A-Za-z._-]', '-')
+}
+
+function Convert-ToWindowsFileVersion {
+    param([string]$RawVersion)
+
+    $matches = [regex]::Matches($RawVersion, '\d+')
+    $parts = @()
+
+    foreach ($match in $matches) {
+        if ($parts.Count -ge 4) {
+            break
+        }
+        $parts += $match.Value
+    }
+
+    while ($parts.Count -lt 4) {
+        $parts += "0"
+    }
+
+    return ($parts -join ".")
+}
+
+function Resolve-InnoSetupCompiler {
+    param([string]$RequestedCompiler)
+
+    if ($RequestedCompiler.Trim()) {
+        if (-not (Test-Path $RequestedCompiler)) {
+            throw "The requested Inno Setup compiler was not found: $RequestedCompiler"
+        }
+        return (Resolve-Path $RequestedCompiler).Path
+    }
+
+    $command = Get-Command "ISCC.exe" -ErrorAction SilentlyContinue
+    if ($command) {
+        return $command.Source
+    }
+
+    $programFilesX86 = [Environment]::GetEnvironmentVariable("ProgramFiles(x86)")
+    $programFiles = [Environment]::GetEnvironmentVariable("ProgramFiles")
+
+    $candidates = @()
+    if ($programFilesX86) {
+        $candidates += Join-Path $programFilesX86 "Inno Setup 6\ISCC.exe"
+    }
+    if ($programFiles) {
+        $candidates += Join-Path $programFiles "Inno Setup 6\ISCC.exe"
+    }
+
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path $candidate)) {
+            return (Resolve-Path $candidate).Path
+        }
+    }
+
+    throw @"
+Could not find ISCC.exe, the Inno Setup compiler.
+
+Install Inno Setup 6, add ISCC.exe to PATH, or pass:
+  -InnoSetupCompiler "C:\Path\To\ISCC.exe"
+"@
+}
+
+if ($ForcePyInstaller -and $SkipPyInstaller) {
+    throw "Use either -ForcePyInstaller or -SkipPyInstaller, not both."
+}
+
+$repoRoot = Resolve-RepositoryRoot
+$issPath = Join-Path $repoRoot "build_tools\windows\gonet_wizard.iss"
+$specPath = Join-Path $repoRoot "build_tools\pyinstaller\gonet_wizard_gui.spec"
+
+if (-not (Test-Path $issPath)) {
+    throw "Inno Setup script not found: $issPath"
+}
+
+if (-not (Test-Path $specPath)) {
+    throw "PyInstaller spec not found: $specPath"
+}
+
+$resolvedSourceDir = if ($SourceDir.Trim()) {
+    (Resolve-Path $SourceDir).Path
+} else {
+    Join-Path $repoRoot "dist\GONet Wizard"
+}
+
+$resolvedOutputDir = if ($OutputDir.Trim()) {
+    if (-not (Test-Path $OutputDir)) {
+        New-Item -ItemType Directory -Path $OutputDir | Out-Null
+    }
+    (Resolve-Path $OutputDir).Path
+} else {
+    Join-Path $repoRoot "dist"
+}
+
+if (-not (Test-Path $resolvedOutputDir)) {
+    New-Item -ItemType Directory -Path $resolvedOutputDir | Out-Null
+}
+
+$shouldRunPyInstaller = -not $SkipPyInstaller -and ($ForcePyInstaller -or -not (Test-Path $resolvedSourceDir))
+
+if ($shouldRunPyInstaller) {
+    Write-Step "Building frozen GUI app with PyInstaller"
+    Push-Location $repoRoot
+    try {
+        & python -m PyInstaller $specPath --clean --noconfirm
+        if ($LASTEXITCODE -ne 0) {
+            throw "PyInstaller failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+} else {
+    Write-Step "Reusing existing PyInstaller output"
+}
+
+$exePath = Join-Path $resolvedSourceDir "GONet Wizard.exe"
+if (-not (Test-Path $exePath)) {
+    throw "Frozen GUI executable not found: $exePath"
+}
+
+$appVersion = Resolve-PythonVersion -RepositoryRoot $repoRoot
+$safeVersion = Convert-ToSafeFileVersion -RawVersion $appVersion
+$appFileVersion = Convert-ToWindowsFileVersion -RawVersion $appVersion
+$outputBaseFilename = "GONet-Wizard-$safeVersion-Windows-x64-unsigned-Setup"
+$iscc = Resolve-InnoSetupCompiler -RequestedCompiler $InnoSetupCompiler
+
+Write-Step "Building Windows installer with Inno Setup"
+Write-Host "Repository root : $repoRoot"
+Write-Host "Source folder   : $resolvedSourceDir"
+Write-Host "Output folder   : $resolvedOutputDir"
+Write-Host "Version         : $appVersion"
+Write-Host "File version    : $appFileVersion"
+Write-Host "Compiler        : $iscc"
+
+$isccArgs = @(
+    "/DAppVersion=$appVersion",
+    "/DAppFileVersion=$appFileVersion",
+    "/DSourceDir=$resolvedSourceDir",
+    "/DOutputDir=$resolvedOutputDir",
+    "/DOutputBaseFilename=$outputBaseFilename",
+    $issPath
+)
+
+Push-Location $repoRoot
+try {
+    & $iscc @isccArgs
+
+    if ($LASTEXITCODE -ne 0) {
+        throw "Inno Setup failed with exit code $LASTEXITCODE."
+    }
+}
+finally {
+    Pop-Location
+}
+
+$installerPath = Join-Path $resolvedOutputDir "$outputBaseFilename.exe"
+if (-not (Test-Path $installerPath)) {
+    throw "Installer was not created: $installerPath"
+}
+
+Write-Step "Installer created"
+Write-Host $installerPath -ForegroundColor Green
+
+if (-not $NoChecksum) {
+    $checksumPath = Join-Path $resolvedOutputDir "SHA256SUMS-Windows.txt"
+    $hash = Get-FileHash -Algorithm SHA256 $installerPath
+    "{0}  {1}" -f $hash.Hash.ToLowerInvariant(), (Split-Path -Leaf $installerPath) | Set-Content -Encoding ASCII $checksumPath
+    Write-Host "Checksum file  : $checksumPath" -ForegroundColor Green
+}

--- a/build_tools/windows/gonet_wizard.iss
+++ b/build_tools/windows/gonet_wizard.iss
@@ -1,0 +1,75 @@
+; Inno Setup script for the GONet Wizard Windows desktop installer.
+;
+; This script expects a PyInstaller one-dir GUI build in:
+;   dist\GONet Wizard\
+;
+; Build it directly with ISCC.exe or through build_installer.ps1.
+
+#define MyAppName "GONet Wizard"
+#define MyAppExeName "GONet Wizard.exe"
+#define MyAppPublisher "GONet Wizard"
+#define MyAppURL "https://github.com/gterreran/GONet_Wizard"
+
+#ifndef AppVersion
+#define AppVersion "0.0.0"
+#endif
+
+#ifndef AppFileVersion
+#define AppFileVersion "0.0.0.0"
+#endif
+
+#ifndef SourceDir
+#define SourceDir "..\..\dist\GONet Wizard"
+#endif
+
+#ifndef OutputDir
+#define OutputDir "..\..\dist"
+#endif
+
+#ifndef OutputBaseFilename
+#define OutputBaseFilename "GONet-Wizard-" + AppVersion + "-Windows-x64-unsigned-Setup"
+#endif
+
+[Setup]
+AppId={{2AEE4DF7-8A7E-4DA4-9A92-BBA8C0320B34}
+AppName={#MyAppName}
+AppVersion={#AppVersion}
+AppPublisher={#MyAppPublisher}
+AppPublisherURL={#MyAppURL}
+AppSupportURL={#MyAppURL}
+AppUpdatesURL={#MyAppURL}/releases
+DefaultDirName={localappdata}\Programs\GONet Wizard
+DefaultGroupName={#MyAppName}
+DisableProgramGroupPage=yes
+OutputDir={#OutputDir}
+OutputBaseFilename={#OutputBaseFilename}
+SetupIconFile=..\..\GONet_Wizard\static\img\logo\GONet_Wizard.ico
+Compression=lzma2
+SolidCompression=yes
+WizardStyle=modern
+ArchitecturesAllowed=x64compatible
+ArchitecturesInstallIn64BitMode=x64compatible
+PrivilegesRequired=lowest
+UninstallDisplayIcon={app}\{#MyAppExeName}
+VersionInfoCompany={#MyAppPublisher}
+VersionInfoDescription={#MyAppName} installer
+VersionInfoProductName={#MyAppName}
+VersionInfoVersion={#AppFileVersion}
+VersionInfoProductVersion={#AppFileVersion}
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+
+[Files]
+Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"
+Name: "{group}\Uninstall {#MyAppName}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#MyAppName}"; Filename: "{app}\{#MyAppExeName}"; Tasks: desktopicon
+
+[Run]
+Filename: "{app}\{#MyAppExeName}"; Description: "Launch {#MyAppName}"; Flags: nowait postinstall skipifsilent

--- a/docs/source/developer_notes/packaging.rst
+++ b/docs/source/developer_notes/packaging.rst
@@ -297,6 +297,11 @@ The Windows installer creates a Start Menu shortcut and offers an optional
 Desktop shortcut. It does not add ``GONet_Wizard`` or ``gonet-wizard`` commands
 to ``PATH``. The Python package remains the supported CLI installation path.
 
+The GitHub Actions Windows workflow uses the same PowerShell wrapper. Keep
+``build_tools/windows/build_installer.ps1`` as the single source of truth for
+installer creation so local Windows builds and CI release builds behave the same
+way.
+
 .. note::
 
    The Windows GUI uses PyWebView. Modern Windows machines usually already have

--- a/docs/source/developer_notes/packaging.rst
+++ b/docs/source/developer_notes/packaging.rst
@@ -91,6 +91,8 @@ Key Packaging Code Paths
      - PyInstaller specs, hooks, and runtime-selection rules.
    * - ``build_tools/macos/build_dmg.sh``
      - Creates the unsigned macOS drag-and-drop DMG after the ``.app`` build succeeds.
+   * - ``build_tools/windows/``
+     - Inno Setup script, PowerShell build wrapper, and Windows installer notes.
 
 Resource and Runtime Path Rules
 -------------------------------
@@ -263,19 +265,66 @@ Unsigned DMGs are useful for internal testing and early GitHub-only
 distribution, but they are not a substitute for Developer ID signing and
 notarization.
 
+Unsigned Windows Setup.exe
+--------------------------
+
+After the raw Windows PyInstaller app passes smoke tests, create a user-local
+installer with Inno Setup:
+
+.. code-block:: powershell
+
+   powershell -ExecutionPolicy Bypass -File build_tools\windows\build_installer.ps1 -ForcePyInstaller
+
+To reuse an existing ``dist\GONet Wizard\`` folder:
+
+.. code-block:: powershell
+
+   powershell -ExecutionPolicy Bypass -File build_tools\windows\build_installer.ps1 -SkipPyInstaller
+
+The default output name is versioned, architecture-specific, and explicitly
+marked unsigned:
+
+.. code-block:: text
+
+   dist\GONet-Wizard-<version>-Windows-x64-unsigned-Setup.exe
+   dist\SHA256SUMS-Windows.txt
+
+The first Windows installer intentionally installs per-user under
+``%LOCALAPPDATA%\Programs\GONet Wizard``. This avoids administrator prompts
+and keeps the installer appropriate for early GitHub-only distribution.
+
+The Windows installer creates a Start Menu shortcut and offers an optional
+Desktop shortcut. It does not add ``GONet_Wizard`` or ``gonet-wizard`` commands
+to ``PATH``. The Python package remains the supported CLI installation path.
+
+.. note::
+
+   The Windows GUI uses PyWebView. Modern Windows machines usually already have
+   the Microsoft Edge WebView2 Runtime installed, but this should remain part of
+   the Windows smoke-test checklist. If users report that the desktop window
+   cannot open, check WebView2 availability before changing the PyInstaller
+   rules.
+
 Smoke Test Checklist
 --------------------
 
 Before publishing a packaging artifact, run a clean build and test the frozen
 app, not only the source checkout.
 
-Recommended local test:
+Recommended macOS local test:
 
 .. code-block:: bash
 
    pytest
    rm -rf build dist
    build_tools/macos/build_dmg.sh --force-pyinstaller
+
+Recommended Windows local test:
+
+.. code-block:: powershell
+
+   pytest
+   powershell -ExecutionPolicy Bypass -File build_tools\windows\build_installer.ps1 -ForcePyInstaller
 
 Then install or open the generated app and check:
 
@@ -320,17 +369,17 @@ For internal testing, users can usually control-click the app and choose
 ``Open``, or allow it from ``System Settings > Privacy & Security`` after the
 first blocked launch. For wider distribution, plan for signing and notarization.
 
-Future Windows Packaging
-------------------------
+Windows Packaging Notes
+-----------------------
 
-Windows packaging should follow the same architecture:
+Windows packaging follows the same architecture as macOS:
 
 * keep the Python package and command system unchanged;
 * build a GUI executable from the desktop entry point;
-* keep the CLI executable available for advanced users;
-* wrap the frozen app in a Windows installer rather than committing generated files to git;
-* publish installers as GitHub Release assets.
+* keep the Python package as the supported CLI installation path;
+* wrap the frozen GUI app in an installer rather than committing generated files to git;
+* publish installers as GitHub Release assets after local validation.
 
-The likely Windows path is a PyInstaller build followed by an Inno Setup
-installer. Windows-specific work should be validated on a real Windows machine
-or Windows runner before publishing user-facing artifacts.
+The current Windows path is a PyInstaller one-dir build followed by an Inno
+Setup installer. Validate both the raw frozen app and the installed app on a real
+Windows machine before publishing user-facing artifacts.

--- a/docs/source/developer_notes/release_workflow.rst
+++ b/docs/source/developer_notes/release_workflow.rst
@@ -94,15 +94,27 @@ run the same GUI smoke test, uninstall, and reinstall once.
 Manual GitHub Actions Build
 ---------------------------
 
-The macOS workflow is designed to be runnable manually from the GitHub Actions
-tab. A manual run should:
+The macOS and Windows packaging workflows are designed to be runnable manually
+from the GitHub Actions tab. A manual run should:
 
-* build the unsigned macOS DMG on a GitHub-hosted macOS runner;
-* generate a SHA-256 checksum file;
+* build the unsigned platform installer on a GitHub-hosted runner;
+* generate or include a SHA-256 checksum file;
 * upload a short-lived Actions artifact for testing.
 
 Use manual workflow runs for candidate builds that should be tested before a
 tagged release exists.
+
+For Windows test builds, the workflow installs Inno Setup on the runner and then
+runs ``build_tools/windows/build_installer.ps1``. After the workflow exists on
+the selected branch, a manual Windows build can also be triggered from the
+GitHub CLI:
+
+.. code-block:: bash
+
+   gh workflow run package-windows.yml \
+     --ref windows-installer \
+     -f version=0.0.0-windows-test \
+     -f force_pyinstaller=true
 
 Tagged Release Build
 --------------------
@@ -118,18 +130,14 @@ The packaging workflow should build the release artifact and upload it to a
 draft GitHub Release for that tag. Keeping the release as a draft provides a
 final review step before users see the installer.
 
-A typical release should contain:
+A typical release can contain platform-specific artifacts such as:
 
 .. code-block:: text
 
    GONet-Wizard-X.Y.Z-macOS-arm64-unsigned.dmg
-   SHA256SUMS.txt
-
-The same release can also contain the Windows installer:
-
-.. code-block:: text
-
+   SHA256SUMS-macOS.txt
    GONet-Wizard-X.Y.Z-Windows-x64-unsigned-Setup.exe
+   SHA256SUMS-Windows.txt
 
 Versioned Artifact Names
 ------------------------
@@ -242,8 +250,9 @@ Windows packaging follows the same release model:
 * upload the installer to GitHub Releases;
 * avoid committing generated ``.exe`` files to git.
 
-A Windows GitHub Actions workflow should be added only after the local Inno
-Setup installer path has been validated on a Windows machine.
+The Windows GitHub Actions workflow should use the same local build script as
+the validated Windows machine path. This keeps local installer testing and
+release automation aligned.
 
 Release Checklist
 -----------------

--- a/docs/source/developer_notes/release_workflow.rst
+++ b/docs/source/developer_notes/release_workflow.rst
@@ -81,6 +81,16 @@ Then open the generated DMG, drag ``GONet Wizard.app`` to ``Applications`` or a
 temporary test folder, and run the smoke test from
 :doc:`desktop packaging developer notes <packaging>`.
 
+For Windows:
+
+.. code-block:: powershell
+
+   pytest
+   powershell -ExecutionPolicy Bypass -File build_tools\windows\build_installer.ps1 -ForcePyInstaller
+
+Then run the generated ``Setup.exe``, launch GONet Wizard from the Start Menu,
+run the same GUI smoke test, uninstall, and reinstall once.
+
 Manual GitHub Actions Build
 ---------------------------
 
@@ -115,12 +125,11 @@ A typical release should contain:
    GONet-Wizard-X.Y.Z-macOS-arm64-unsigned.dmg
    SHA256SUMS.txt
 
-When Windows packaging is added, the same release can also contain the Windows
-installer:
+The same release can also contain the Windows installer:
 
 .. code-block:: text
 
-   GONet-Wizard-X.Y.Z-Windows-x64-Setup.exe
+   GONet-Wizard-X.Y.Z-Windows-x64-unsigned-Setup.exe
 
 Versioned Artifact Names
 ------------------------
@@ -224,16 +233,17 @@ produces and tests a universal binary.
 Windows Release Path
 --------------------
 
-Windows packaging should follow the same release model:
+Windows packaging follows the same release model:
 
-* validate the frozen executable on Windows;
-* wrap it with an installer script, likely Inno Setup;
+* validate the source checkout on Windows;
+* validate the raw PyInstaller executable on Windows;
+* wrap the frozen GUI app with the Inno Setup script in ``build_tools/windows``;
 * account for the WebView2 runtime expectation;
 * upload the installer to GitHub Releases;
 * avoid committing generated ``.exe`` files to git.
 
-A Windows GitHub Actions workflow can be added after the Windows PyInstaller and
-installer path has been validated on a Windows machine or Windows runner.
+A Windows GitHub Actions workflow should be added only after the local Inno
+Setup installer path has been validated on a Windows machine.
 
 Release Checklist
 -----------------

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -45,16 +45,22 @@ Desktop app installation
 ------------------------
 
 Desktop installers are distributed through the GitHub Releases page when a
-packaged build is available. On macOS, the current packaging path produces a
-drag-and-drop DMG containing ``GONet Wizard.app``. After dragging the app to
-``Applications``, launch it by double-clicking the icon.
+packaged build is available.
+
+On macOS, the packaging path produces a drag-and-drop DMG containing
+``GONet Wizard.app``. After dragging the app to ``Applications``, launch it by
+double-clicking the icon.
+
+On Windows, the packaging path produces a ``Setup.exe`` installer. The installer
+adds a Start Menu shortcut and can optionally add a Desktop shortcut. It is a
+GUI installer only: it does not install terminal commands or modify ``PATH``.
 
 The desktop app opens the GUI launcher. It does not install command-line entry
 points, modify shell startup files, or add anything to ``PATH``.
 
-Early macOS DMGs may be unsigned. If macOS blocks the app on first launch, see
-the release notes and the ``README-FIRST.txt`` file included in the DMG for the
-expected Gatekeeper behavior.
+Early macOS DMGs and Windows installers may be unsigned. If your operating
+system blocks the app on first launch, see the release notes and any README file
+included with the release artifact for expected unsigned-build behavior.
 
 Creating a Python environment
 -----------------------------
@@ -210,8 +216,12 @@ You do not need to run ``setup.py`` directly. It exists only for compatibility a
 
 .. ----
 
-Installation tips for Windows Users
------------------------------------
+Python package installation tips for Windows users
+--------------------------------------------------
+
+The Windows desktop installer does not require Python or Git. This section is
+only for users who want to install the Python package so they can use the CLI
+commands or develop the project locally.
 
 Before installing the GONet Wizard package, ensure that you have both Python and Git installed and accessible from your terminal or command prompt.
 

--- a/tests/test_extractors_more.py
+++ b/tests/test_extractors_more.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from astropy.time import Time
+from pathlib import Path
 
 from GONet_Wizard.GONet_utils import DATA_SPEC
 from GONet_Wizard.GONet_utils.src.extractors.astro_info import AstroInfo
@@ -26,7 +27,9 @@ def test_file_info_extracts_filename_camera_unix_time_and_context_time():
     results, context = FileInfo().extract({"file_list": files}, {})
 
     assert results["files"] == files
-    assert results[DATA_SPEC["filename"].key] == files
+    assert [Path(p) for p in results[DATA_SPEC["filename"].key]] == [
+        Path(p) for p in files
+    ]
     assert results[DATA_SPEC["camera"].key] == [11, 12]
     assert results[DATA_SPEC["unix_time"].key] == [1700000000, 1700003600]
     np.testing.assert_array_equal(context["time"].unix.astype(int), [1700000000, 1700003600])

--- a/tests/test_main_branding.py
+++ b/tests/test_main_branding.py
@@ -3,6 +3,7 @@ import sys
 import types
 
 import pytest
+from pathlib import Path
 
 
 def test_main_delegates_to_cli(monkeypatch):
@@ -24,19 +25,23 @@ def test_branding_resource_path_uses_pyinstaller_meipass(monkeypatch):
     branding = pytest.importorskip("GONet_Wizard._branding")
     monkeypatch.setattr(branding.sys, "_MEIPASS", "/tmp/gonet-bundle", raising=False)
 
-    assert branding._resource_path("static", "icon.ico") == "/tmp/gonet-bundle/static/icon.ico"
+    assert Path(branding._resource_path("static", "icon.ico")) == (
+        Path("/tmp/gonet-bundle") / "static" / "icon.ico"
+    )
 
 
 def test_branding_default_icon_path_depends_on_platform(monkeypatch):
     branding = pytest.importorskip("GONet_Wizard._branding")
 
     monkeypatch.setattr(branding.platform, "system", lambda: "Darwin")
-    assert branding._default_icon_path().endswith("static/img/logo/GONet_Wizard.icns")
+    icon_path = Path(branding._default_icon_path())
+    assert icon_path.parts[-4:] == ("static", "img", "logo", "GONet_Wizard.icns")
 
     monkeypatch.setattr(branding.platform, "system", lambda: "Linux")
-    assert branding._default_icon_path().endswith("static/img/logo/GONet_Wizard.ico")
+    icon_path = Path(branding._default_icon_path())
+    assert icon_path.parts[-4:] == ("static", "img", "logo", "GONet_Wizard.ico")
 
-
+    
 def test_set_dock_icon_once_is_noop_if_already_set(monkeypatch):
     branding = pytest.importorskip("GONet_Wizard._branding")
     monkeypatch.setattr(branding, "_ICON_SET", True)


### PR DESCRIPTION
## Summary

This PR adds Windows desktop packaging support for GONet Wizard.

It builds on the existing desktop-packaging infrastructure added for macOS and adds a Windows installer path based on PyInstaller + Inno Setup. The goal is to let Windows users install and launch the GONet Wizard GUI like a normal desktop application, while keeping the Python package installation path for CLI users and developers.

This PR adds:

* Windows-compatible PyInstaller validation for the GUI app;
* an Inno Setup installer script;
* a PowerShell build wrapper for creating local Windows installers;
* a GitHub Actions workflow for Windows installer artifacts and tagged release assets;
* Windows-specific packaging documentation and smoke-test checklists.

## Main changes

### Windows installer build tools

Adds:

* `build_tools/windows/README.md`
* `build_tools/windows/build_installer.ps1`
* `build_tools/windows/gonet_wizard.iss`

The PowerShell wrapper can either reuse an existing PyInstaller output folder or force a fresh PyInstaller build before creating the installer.

The installer is intentionally GUI-focused. It installs the frozen desktop app and creates user-facing shortcuts, but it does **not** install the `GONet_Wizard` / `gonet-wizard` CLI commands or modify the user’s `PATH`.

### Inno Setup installer

Adds an Inno Setup script that packages the PyInstaller output folder into a Windows installer.

The installer:

* installs GONet Wizard per-user under `%LOCALAPPDATA%\Programs\GONet Wizard`;
* does not require administrator privileges;
* creates a Start Menu shortcut;
* optionally creates a Desktop shortcut;
* supports uninstall/reinstall through normal Windows app management;
* keeps the Windows installer story aligned with the macOS DMG story: desktop installer for GUI users, Python package for CLI users.

The build wrapper also handles the distinction between the human-readable application version and the numeric Windows file-version metadata required by Inno Setup.

### Windows GitHub Actions workflow

Adds:

* `.github/workflows/package-windows.yml`

The workflow mirrors the macOS packaging workflow:

* manual `workflow_dispatch` builds;
* `v*` tag-triggered release builds;
* Python 3.10 setup;
* package installation with build extras;
* Inno Setup installation;
* Windows installer generation;
* SHA256 checksum generation;
* short-lived Actions artifact upload;
* tagged release asset upload to a draft GitHub Release.

### Documentation

Updates packaging and release documentation to describe the Windows installer workflow, local smoke tests, GitHub Actions artifact generation, and the continued separation between GUI desktop installers and CLI installation through `pip` / `pipx`.

## Validation

Tested locally on Windows:

* editable package install with build/dev dependencies;
* CLI entry points;
* source-mode GUI launch;
* PyInstaller GUI build;
* frozen GUI launch from the PyInstaller `dist` folder;
* main launcher;
* show workflow;
* extract workflow;
* dashboard workflow;
* Inno Setup installer creation;
* installer launch;
* installation to the expected per-user location;
* Start Menu / shortcut launch;
* uninstall;
* reinstall.

The frozen Windows app built successfully and the collected PyInstaller app was approximately 293 MB before installer wrapping.

## Notes

This PR keeps the Windows installer unsigned. Users may see normal Windows security warnings for an unsigned installer.

This PR also does not change the CLI installation model. Users who want terminal commands should install the Python package with `pip` or `pipx`.

Code signing, WebView2 bootstrapping, and optional frozen CLI distribution can be handled in future follow-up work if needed.
