### PR TITLE
Add split_raw command for RAW image conversion

### DIFF
--- a/GONet_Wizard/GONet_utils/src/extract_app/extract_callbacks.py
+++ b/GONet_Wizard/GONet_utils/src/extract_app/extract_callbacks.py
@@ -82,6 +82,11 @@ from GONet_Wizard.GONet_utils.src.extractors import extract_all
 from GONet_Wizard.GONet_utils.src.extractors.core import extraction_output
 from GONet_Wizard.GONet_dashboard.src.load_save_callbacks import register_json_download, load_json
 from GONet_Wizard.GONet_utils.src.extract_app.extract_server import app
+from GONet_Wizard.GONet_utils.src.extract_app.extract_gui import (
+    EXTRACT_GUI_WINDOW_KEY,
+    cancel_interactive_extraction_if_unsubmitted,
+    mark_interactive_extraction_submitted,
+)
 import GONet_Wizard.GONet_utils.src.extract_app.shapes.base as base
 from GONet_Wizard.GONet_utils.src.extract_app.extract_layout import files_path
 from GONet_Wizard.logging_utils import PACKAGE_LOGGER_NAME
@@ -1181,6 +1186,8 @@ def extraction_button(_, extraction_params, path, selected_shape, n):
             _clear_terminal_stream_if_current(terminal_stream)
         return no_update, f"Extraction failed: {e}", "extract-error-banner is-visible"
 
+    mark_interactive_extraction_submitted()
+
     if terminal_stream is not None:
         terminal_stream.append(
             "Interactive extraction submitted. Closing setup window; "
@@ -1198,7 +1205,7 @@ def extraction_button(_, extraction_params, path, selected_shape, n):
     worker.start()
 
     from GONet_Wizard.ui import WINDOWS
-    WINDOWS.close("extract-gui")
+    WINDOWS.close(EXTRACT_GUI_WINDOW_KEY)
     return no_update, "", "extract-error-banner"
 
 
@@ -1226,14 +1233,8 @@ def exit_app(_):
     :class:`bool`
         Always returns ``True`` to disable the "Exit" button after it has been clicked.
     """
-    terminal_stream = app.server.config.get("terminal_stream")
-    if terminal_stream is not None and not terminal_stream.is_done:
-        terminal_stream.finish(
-            status="error",
-            message="Interactive extraction cancelled before output was written.",
-        )
-        _clear_terminal_stream_if_current(terminal_stream)
+    cancel_interactive_extraction_if_unsubmitted()
 
     from GONet_Wizard.ui import WINDOWS
-    WINDOWS.close("extract-gui")
+    WINDOWS.close(EXTRACT_GUI_WINDOW_KEY)
     return True

--- a/GONet_Wizard/GONet_utils/src/extract_app/extract_gui.py
+++ b/GONet_Wizard/GONet_utils/src/extract_app/extract_gui.py
@@ -35,6 +35,43 @@ from typing import Any, List, Optional
 from GONet_Wizard.GONet_utils.src.extract_app.extract_server import app
 from GONet_Wizard.ui.dash_runner import DashLaunchSpec, ensure_dash_running
 
+
+EXTRACT_GUI_WINDOW_KEY = "extract-gui"
+_INTERACTIVE_EXTRACTION_SUBMITTED_KEY = "interactive_extraction_submitted"
+
+
+def mark_interactive_extraction_submitted() -> None:
+    """Mark the active interactive extraction session as intentionally submitted."""
+    app.server.config[_INTERACTIVE_EXTRACTION_SUBMITTED_KEY] = True
+
+
+def _clear_terminal_stream_if_current(terminal_stream: Optional[Any]) -> None:
+    """Clear ``terminal_stream`` from app config if it is still active."""
+    if terminal_stream is not None and app.server.config.get("terminal_stream") is terminal_stream:
+        app.server.config["terminal_stream"] = None
+
+
+def cancel_interactive_extraction_if_unsubmitted() -> None:
+    """Finish the form stream when the extraction window closes without Extract.
+
+    Closing the pywebview window via the title-bar X bypasses Dash callbacks.
+    The launcher form is still waiting on its original streaming response, so
+    this window-close hook emits the same final status that the explicit Exit
+    button would have emitted.  If the user clicked Extract, the worker thread
+    owns the stream and this hook deliberately does nothing.
+    """
+    if app.server.config.get(_INTERACTIVE_EXTRACTION_SUBMITTED_KEY):
+        return
+
+    terminal_stream = app.server.config.get("terminal_stream")
+    if terminal_stream is not None and not terminal_stream.is_done:
+        terminal_stream.finish(
+            status="error",
+            message="Interactive extraction cancelled before output was written.",
+        )
+    _clear_terminal_stream_if_current(terminal_stream)
+
+
 def _configure_extract_gui(
     data_files: List[str],
     channels: Optional[List[str]] = None,
@@ -75,6 +112,7 @@ def _configure_extract_gui(
         output_type=output_type,
         terminal_stream=terminal_stream,
     )
+    app.server.config[_INTERACTIVE_EXTRACTION_SUBMITTED_KEY] = False
 
 
 def _layout(_app):

--- a/GONet_Wizard/cli.py
+++ b/GONet_Wizard/cli.py
@@ -76,6 +76,7 @@ Available Commands
 - ``dashboard`` (:mod:`GONet_Wizard.commands.run_dashboard`) — Launch the interactive dashboard.
 - ``gui`` (:mod:`GONet_Wizard.commands.gui`) — Open the unified GUI launcher window.
 - ``build_full_array`` (:mod:`GONet_Wizard.commands.build_full_array`) — Build/process full-array products.
+- ``split_raw`` (:mod:`GONet_Wizard.commands.split_raw`) — Convert RAW GONet JPEG files to standard TIFF/JPEG products.
 
 Experimental remote-camera commands live under :mod:`GONet_Wizard.commands.connect_commands`,
 but they are intentionally not registered in the public command tree yet.

--- a/GONet_Wizard/commands/__init__.py
+++ b/GONet_Wizard/commands/__init__.py
@@ -76,6 +76,8 @@ Available Commands
     Launch the interactive Dash-based GONet Wizard dashboard in a managed window.
 :mod:`GONet_Wizard.commands.build_full_array`
     Build or process full-array products from GONet inputs.
+:mod:`GONet_Wizard.commands.split_raw`
+    Convert RAW GONet JPEG files into standard TIFF and JPEG images.
 :mod:`GONet_Wizard.commands.gui`
     Launch the unified GUI launcher window.
 
@@ -92,11 +94,11 @@ Constants
 # a separate package or optional extension later.
 # "GONet_Wizard.commands.connect_commands",
 
-from GONet_Wizard.commands import show, show_meta, extract, run_dashboard, build_full_array, gui
+from GONet_Wizard.commands import show, show_meta, extract, run_dashboard, build_full_array, split_raw, gui
 #from GONet_Wizard.commands import connect_commands
 from .cli_core import ParserSpec
 
-COMMANDS = (show, show_meta, extract, run_dashboard, build_full_array, gui)
+COMMANDS = (show, show_meta, extract, run_dashboard, build_full_array, split_raw, gui)
 
 PARSER = ParserSpec(
     dest="command",

--- a/GONet_Wizard/commands/extract.py
+++ b/GONet_Wizard/commands/extract.py
@@ -506,13 +506,22 @@ def cli_handler(args: argparse.Namespace):
             channels.append("blue")
 
     if args.shape in {None, "interactive"}:
-        from GONet_Wizard.GONet_utils.src.extract_app.extract_gui import (
-            ensure_extraction_gui_running,
-        )
+        import importlib
+
         from GONet_Wizard.commands.ui_bridge import WindowRequest
         from GONet_Wizard.ui.windows import WindowSpec
 
-        url = ensure_extraction_gui_running(
+        extract_gui = importlib.import_module(
+            "GONet_Wizard.GONet_utils.src.extract_app.extract_gui"
+        )
+        window_key = getattr(extract_gui, "EXTRACT_GUI_WINDOW_KEY", "extract-gui")
+        on_closed = getattr(
+            extract_gui,
+            "cancel_interactive_extraction_if_unsubmitted",
+            None,
+        )
+
+        url = extract_gui.ensure_extraction_gui_running(
             data_files=[str(p) for p in files],
             debug=bool(args.debug),
             port=int(args.port),
@@ -523,12 +532,13 @@ def cli_handler(args: argparse.Namespace):
         )
 
         return WindowRequest(
-            key="extract-gui",
+            key=window_key,
             spec=WindowSpec(
                 title="GONet Wizard Extraction GUI",
                 url=url,
                 width=1250,
                 height=750,
+                on_closed=on_closed,
             ),
         )
 

--- a/GONet_Wizard/commands/split_raw.py
+++ b/GONet_Wizard/commands/split_raw.py
@@ -1,0 +1,398 @@
+"""
+CLI command for splitting RAW GONet JPEG files into standard images.
+
+The ``split_raw`` command reads one or more original GONet RAW ``.jpg`` files
+and writes standard image products next to each input by default:
+
+- a 16-bit TIFF file (``<stem>.tiff``), and
+- a standard 8-bit JPEG file (``<stem>.jpeg``).
+
+When an output directory is supplied, the command keeps products organized in
+separate ``tiffs`` and ``jpegs`` subdirectories. TIFF products do not apply white
+balance by default so their pixel values remain as faithful as possible to the
+RAW data for scientific extraction. JPEG products keep white balance enabled by
+default because they are usually intended for visual inspection.
+
+The image loading and writing are delegated to
+:class:`GONet_Wizard.GONet_utils.GONetFile`, which already knows how to parse
+GONet RAW JPEG files and export the processed RGB channels. This module keeps
+the command-layer behavior focused on CLI/GUI arguments, path handling, and
+safe overwrite checks.
+
+Constants
+---------
+:data:`COMMAND`
+    Declarative command specification used by the shared parser builder and GUI
+    form generator.
+
+Functions
+---------
+:func:`output_paths_for_raw`
+    Resolve the TIFF and JPEG output paths for one input file.
+:func:`split_raw_file`
+    Convert a single RAW input file into the requested output products.
+:func:`split_raw_files`
+    Convert a sequence of RAW input files.
+:func:`cli_handler`
+    Execute the command after argparse has populated the namespace.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections import namedtuple
+from pathlib import Path
+from typing import Iterable, Literal
+
+from GONet_Wizard.GONet_utils import GONetFile
+from GONet_Wizard.commands.cli_core import CommandSpec, ExpandFilenames, filter_by_ext
+
+OutputFormat = Literal["both", "tiff", "jpeg"]
+
+
+class SplitRawOutput(namedtuple("_SplitRawOutput", ["input_file", "tiff", "jpeg"])):
+    """Small return container for paths written by one conversion."""
+
+    __slots__ = ()
+
+
+COMMAND = CommandSpec(
+    name="split_raw",
+    help="Convert RAW GONet .jpg files into standard TIFF and JPEG images.",
+    args=[
+        {
+            "flags": ["input"],
+            "nargs": "+",
+            "action": ExpandFilenames,
+            "help": (
+                "Input GONet RAW (*.jpg) file(s), folder(s), glob(s), "
+                "or comma-separated lists."
+            ),
+        },
+        {
+            "flags": ["--outdir"],
+            "type": str,
+            "default": None,
+            "help": (
+                "Optional output directory. When set, TIFF and JPEG products "
+                "are written under tiffs/ and jpegs/ subfolders. Defaults to "
+                "writing next to each input file."
+            ),
+        },
+        {
+            "flags": ["--format"],
+            "choices": ["both", "tiff", "jpeg"],
+            "default": "both",
+            "help": "Output product(s) to write. Default: both.",
+        },
+        {
+            "flags": ["--overwrite"],
+            "action": "store_true",
+            "default": False,
+            "help": "Overwrite existing output files.",
+        },
+        {
+            "flags": ["--tiff-white-balance"],
+            "action": "store_true",
+            "default": False,
+            "help": (
+                "Apply metadata white-balance gains to TIFF outputs. Disabled "
+                "by default to preserve raw-like pixel counts for extraction."
+            ),
+        },
+        {
+            "flags": ["--no-jpeg-white-balance"],
+            "action": "store_true",
+            "default": False,
+            "help": (
+                "Disable metadata white-balance gains for JPEG outputs. JPEG "
+                "white balance is enabled by default."
+            ),
+        },
+    ],
+)
+
+
+def _normalize_format(output_format: str) -> OutputFormat:
+    """
+    Validate and normalize an output-format string.
+
+    Parameters
+    ----------
+    output_format : :class:`str`
+        Requested output format. Supported values are ``"both"``, ``"tiff"``,
+        and ``"jpeg"``.
+
+    Returns
+    -------
+    :class:`str`
+        The normalized output format.
+
+    Raises
+    ------
+    ValueError
+        If ``output_format`` is not supported.
+    """
+    normalized = str(output_format).lower()
+    if normalized not in {"both", "tiff", "jpeg"}:
+        raise ValueError(
+            "output_format must be one of 'both', 'tiff', or 'jpeg'."
+        )
+    return normalized  # type: ignore[return-value]
+
+
+def _product_dir(source: Path, outdir: str | Path | None, product_folder: str) -> Path:
+    """
+    Resolve the parent directory for one output product kind.
+
+    Parameters
+    ----------
+    source : :class:`pathlib.Path`
+        Source RAW input path.
+    outdir : :class:`str` or :class:`pathlib.Path`, optional
+        Base output directory. If omitted, outputs stay next to ``source``.
+    product_folder : :class:`str`
+        Product subfolder name used when ``outdir`` is supplied.
+
+    Returns
+    -------
+    :class:`pathlib.Path`
+        Directory that should contain the requested product.
+    """
+    if outdir is None:
+        return source.parent
+    return Path(outdir) / product_folder
+
+
+def output_paths_for_raw(
+    input_file: str | Path,
+    outdir: str | Path | None = None,
+    output_format: str = "both",
+) -> SplitRawOutput:
+    """
+    Resolve standard TIFF/JPEG output paths for one RAW input file.
+
+    By default, outputs are written next to the input. TIFF outputs use
+    ``<stem>.tiff`` and JPEG outputs use ``<stem>.jpeg`` so the generated JPEG
+    does not overwrite the source RAW ``.jpg`` file. When ``outdir`` is supplied,
+    TIFF outputs are written under ``outdir/tiffs`` and JPEG outputs under
+    ``outdir/jpegs``.
+
+    Parameters
+    ----------
+    input_file : :class:`str` or :class:`pathlib.Path`
+        Source RAW GONet JPEG file.
+    outdir : :class:`str` or :class:`pathlib.Path`, optional
+        Base directory in which outputs should be written. If omitted, the input
+        file's parent directory is used.
+    output_format : :class:`str`, optional
+        Which product(s) to create: ``"both"`` (default), ``"tiff"``, or
+        ``"jpeg"``.
+
+    Returns
+    -------
+    :class:`SplitRawOutput`
+        Named tuple containing the source path and requested output paths.
+    """
+    fmt = _normalize_format(output_format)
+    source = Path(input_file)
+    stem = source.stem
+
+    return SplitRawOutput(
+        input_file=source,
+        tiff=(
+            _product_dir(source, outdir, "tiffs") / f"{stem}.tiff"
+            if fmt in {"both", "tiff"}
+            else None
+        ),
+        jpeg=(
+            _product_dir(source, outdir, "jpegs") / f"{stem}.jpeg"
+            if fmt in {"both", "jpeg"}
+            else None
+        ),
+    )
+
+
+def _check_output_paths(paths: SplitRawOutput, overwrite: bool) -> None:
+    """
+    Validate output paths before writing products.
+
+    Parameters
+    ----------
+    paths : :class:`SplitRawOutput`
+        Resolved output path bundle.
+    overwrite : :class:`bool`
+        Whether existing outputs may be overwritten.
+
+    Raises
+    ------
+    FileExistsError
+        If an output exists and ``overwrite`` is False.
+    ValueError
+        If a requested output path would overwrite the input file itself.
+    """
+    requested = [p for p in (paths.tiff, paths.jpeg) if p is not None]
+    source = paths.input_file.resolve()
+
+    for path in requested:
+        resolved = path.resolve()
+        if resolved == source:
+            raise ValueError(f"Refusing to overwrite input file: {path}")
+        if path.exists() and not overwrite:
+            raise FileExistsError(
+                f"Output file already exists: {path}. Use --overwrite to replace it."
+            )
+
+
+def split_raw_file(
+    input_file: str | Path,
+    outdir: str | Path | None = None,
+    output_format: str = "both",
+    overwrite: bool = False,
+    tiff_white_balance: bool = False,
+    jpeg_white_balance: bool = True,
+) -> SplitRawOutput:
+    """
+    Convert one RAW GONet JPEG file into standard image products.
+
+    Parameters
+    ----------
+    input_file : :class:`str` or :class:`pathlib.Path`
+        Source RAW GONet JPEG file.
+    outdir : :class:`str` or :class:`pathlib.Path`, optional
+        Base output directory. If omitted, outputs are written next to the
+        input. If supplied, products are written under ``tiffs`` and ``jpegs``
+        subfolders.
+    output_format : :class:`str`, optional
+        Which product(s) to create: ``"both"`` (default), ``"tiff"``, or
+        ``"jpeg"``.
+    overwrite : :class:`bool`, optional
+        If True, existing outputs may be replaced. Defaults to False.
+    tiff_white_balance : :class:`bool`, optional
+        Whether to apply metadata white-balance gains to TIFF outputs. Defaults
+        to False so TIFF pixel counts remain close to the RAW data.
+    jpeg_white_balance : :class:`bool`, optional
+        Whether to apply metadata white-balance gains to JPEG outputs. Defaults
+        to True for visually useful JPEG products.
+
+    Returns
+    -------
+    :class:`SplitRawOutput`
+        Paths written for this input file.
+    """
+    paths = output_paths_for_raw(input_file, outdir=outdir, output_format=output_format)
+
+    if paths.tiff is not None:
+        paths.tiff.parent.mkdir(parents=True, exist_ok=True)
+    if paths.jpeg is not None:
+        paths.jpeg.parent.mkdir(parents=True, exist_ok=True)
+
+    _check_output_paths(paths, overwrite=overwrite)
+
+    gonet_file = GONetFile.from_file(paths.input_file)
+
+    if paths.tiff is not None:
+        gonet_file.write_to_tiff(str(paths.tiff), white_balance=tiff_white_balance)
+    if paths.jpeg is not None:
+        gonet_file.write_to_jpeg(str(paths.jpeg), white_balance=jpeg_white_balance)
+
+    return paths
+
+
+def split_raw_files(
+    input_files: Iterable[str | Path],
+    outdir: str | Path | None = None,
+    output_format: str = "both",
+    overwrite: bool = False,
+    tiff_white_balance: bool = False,
+    jpeg_white_balance: bool = True,
+) -> list[SplitRawOutput]:
+    """
+    Convert multiple RAW GONet JPEG files into standard image products.
+
+    Parameters
+    ----------
+    input_files : iterable of :class:`str` or :class:`pathlib.Path`
+        Source RAW GONet JPEG files.
+    outdir : :class:`str` or :class:`pathlib.Path`, optional
+        Base output directory for all products. If omitted, each input's parent
+        directory is used. If supplied, products are written under ``tiffs`` and
+        ``jpegs`` subfolders.
+    output_format : :class:`str`, optional
+        Which product(s) to create: ``"both"`` (default), ``"tiff"``, or
+        ``"jpeg"``.
+    overwrite : :class:`bool`, optional
+        If True, existing outputs may be replaced. Defaults to False.
+    tiff_white_balance : :class:`bool`, optional
+        Whether to apply metadata white-balance gains to TIFF outputs. Defaults
+        to False.
+    jpeg_white_balance : :class:`bool`, optional
+        Whether to apply metadata white-balance gains to JPEG outputs. Defaults
+        to True.
+
+    Returns
+    -------
+    list of :class:`SplitRawOutput`
+        Paths written for each input file.
+    """
+    return [
+        split_raw_file(
+            input_file,
+            outdir=outdir,
+            output_format=output_format,
+            overwrite=overwrite,
+            tiff_white_balance=tiff_white_balance,
+            jpeg_white_balance=jpeg_white_balance,
+        )
+        for input_file in input_files
+    ]
+
+
+def _format_written_paths(outputs: Iterable[SplitRawOutput]) -> str:
+    """Return a human-readable summary of written output paths."""
+    lines: list[str] = []
+    for output in outputs:
+        written = [p for p in (output.tiff, output.jpeg) if p is not None]
+        lines.append(f"{output.input_file} -> {', '.join(str(p) for p in written)}")
+    return "\n".join(lines)
+
+
+def cli_handler(args: argparse.Namespace) -> None:
+    """
+    CLI handler for the ``split_raw`` command.
+
+    The handler prints a terminal-friendly summary and intentionally returns
+    ``None``. Returning an HTML-like string would be interpreted by the shared
+    CLI UI bridge as a preview request, which would open an unnecessary window
+    for this terminal-only conversion command.
+
+    Parameters
+    ----------
+    args : :class:`argparse.Namespace`
+        Parsed command-line arguments produced from :data:`COMMAND`.
+
+    Returns
+    -------
+    None
+        Feedback is emitted to stdout so both the terminal and GUI fake terminal
+        receive the same summary.
+
+    Raises
+    ------
+    :class:`~GONet_Wizard.commands.inputs.ExtensionFilterError`
+        If the supplied inputs do not include supported RAW JPEG files.
+    """
+    files = filter_by_ext(args.input, [".jpg"])
+    outputs = split_raw_files(
+        input_files=files,
+        outdir=args.outdir,
+        output_format=args.format,
+        overwrite=bool(args.overwrite),
+        tiff_white_balance=bool(args.tiff_white_balance),
+        jpeg_white_balance=not bool(args.no_jpeg_white_balance),
+    )
+
+    summary = _format_written_paths(outputs)
+    if summary:
+        print(summary)
+    return None

--- a/GONet_Wizard/gui/templates/form_page.html
+++ b/GONet_Wizard/gui/templates/form_page.html
@@ -8,17 +8,17 @@
     <input type="hidden" name="command" value="{{ command_name }}">
   </form>
 
-  {% if command_name in ["extract", "show", "show_meta"] %}
+  {% if command_name in ["extract", "show", "show_meta", "split_raw"] %}
     <section id="command-terminal" class="command-terminal" aria-live="polite">
       <div class="command-terminal-header">
-        <span>{{ "Extraction" if command_name == "extract" else ("Metadata" if command_name == "show_meta" else "Show") }} feedback</span>
+        <span>{{ "Extraction" if command_name == "extract" else ("Metadata" if command_name == "show_meta" else ("Split raw" if command_name == "split_raw" else "Show")) }} feedback</span>
         <span id="terminal-status" class="command-terminal-status is-ready">Ready</span>
       </div>
       <pre id="terminal-output" class="command-terminal-output">Ready. Run {{ command_name }} to see command feedback here.</pre>
     </section>
   {% endif %}
 
-  {% if command_name not in ["extract", "show", "show_meta"] %}
+  {% if command_name not in ["extract", "show", "show_meta", "split_raw"] %}
     <div id="output" class="command-output"></div>
   {% endif %}
 {% endblock %}

--- a/GONet_Wizard/gui/templates/forms/split_raw.html
+++ b/GONet_Wizard/gui/templates/forms/split_raw.html
@@ -1,0 +1,49 @@
+{% set input_id = "split-raw-input" %}
+{% set name = "input" %}
+{% set label = "RAW GONet JPG files or folders" %}
+{% set placeholder = "Type a path/pattern (e.g. /data/*.jpg) or use Browse…" %}
+{% set pick_mode = "files" %}
+{% set help = "You can type wildcards and comma-separated entries. Browse will insert selected paths." %}
+{% include "components/path_picker.html" %}
+
+{% set input_id = "split-raw-outdir" %}
+{% set name = "outdir" %}
+{% set label = "Optional output directory" %}
+{% set placeholder = "Leave blank to write next to each input…" %}
+{% set pick_mode = "folder" %}
+{% set help = "If set, TIFF files are written to a tiffs subfolder and JPEG files are written to a jpegs subfolder." %}
+{% include "components/path_picker.html" %}
+
+<div class="form-group">
+  <label class="form-label" for="split-raw-format">Output products</label>
+  <select id="split-raw-format" name="format" data-cache="1">
+    <option value="both">TIFF and JPEG</option>
+    <option value="tiff">TIFF only</option>
+    <option value="jpeg">JPEG only</option>
+  </select>
+  <div class="form-help">
+    TIFF is written as a 16-bit standard image. JPEG is written as a standard 8-bit image.
+  </div>
+</div>
+
+<div class="form-group">
+  <div class="checkbox-row">
+    <label class="check">
+      <input type="checkbox" name="overwrite" data-cache="1">
+      <span>Overwrite existing outputs</span>
+    </label>
+    <label class="check">
+      <input type="checkbox" name="tiff_white_balance" data-cache="1">
+      <span>Apply white balance to TIFF outputs</span>
+    </label>
+    <label class="check">
+      <input type="checkbox" name="no_jpeg_white_balance" data-cache="1">
+      <span>Disable white balance for JPEG outputs</span>
+    </label>
+  </div>
+  <div class="form-help">
+    TIFF white balance is off by default to preserve scientific pixel counts. JPEG white balance is on by default for visual inspection.
+  </div>
+</div>
+
+<button type="submit">Split raw</button>

--- a/GONet_Wizard/gui/templates/index.html
+++ b/GONet_Wizard/gui/templates/index.html
@@ -7,6 +7,7 @@
       <button onclick="location.href='/cmd/show'">Show Image</button>
       <button onclick="location.href='/cmd/show_meta'">Show Metadata</button>
       <button onclick="location.href='/cmd/extract'">Extract Region</button>
+      <button onclick="location.href='/cmd/split_raw'">Split RAW Images</button>
     </fieldset>
 
     <fieldset>

--- a/GONet_Wizard/ui/windows.py
+++ b/GONet_Wizard/ui/windows.py
@@ -41,7 +41,7 @@ Constants
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Optional, Dict, Union, TYPE_CHECKING
+from typing import Any, Callable, Optional, Dict, Union, TYPE_CHECKING
 import threading
 
 from GONet_Wizard.ui.api import WebviewAPI
@@ -69,12 +69,15 @@ class WindowSpec:
         Window height in pixels.
     resizable : :class:`bool`
         Whether the window is resizable.
+    on_closed : callable, optional
+        Callback invoked after the window is closed and removed from the registry.
     """
     title: str
     url: UrlLike
     width: int = 1200
     height: int = 800
     resizable: bool = True
+    on_closed: Optional[Callable[[], None]] = None
 
 
 class WindowManager:
@@ -146,7 +149,12 @@ class WindowManager:
         except Exception:
             return False
 
-    def _watch_close(self, key: str, win: Any) -> None:
+    def _watch_close(
+        self,
+        key: str,
+        win: Any,
+        on_closed: Optional[Callable[[], None]] = None,
+    ) -> None:
         """
         Wait for a window to close and remove it from the registry.
 
@@ -156,11 +164,14 @@ class WindowManager:
             Registry key associated with the window.
         win : :class:`object`
             pywebview window object to watch.
+        on_closed : callable, optional
+            Callback invoked after ``win`` is closed and unregistered.
 
         Returns
         -------
         None
         """
+        should_notify = False
         try:
             win.events.closed.wait()  # blocks until closed
         finally:
@@ -168,6 +179,13 @@ class WindowManager:
                 cur = self._windows.get(key)
                 if cur is win:
                     self._windows.pop(key, None)
+                    should_notify = True
+
+            if should_notify and on_closed is not None:
+                try:
+                    on_closed()
+                except Exception:
+                    pass
 
     def ensure(self, key: str, spec: WindowSpec) -> Any:
         """
@@ -224,7 +242,11 @@ class WindowManager:
 
             self._windows[key] = win
 
-            t = threading.Thread(target=self._watch_close, args=(key, win), daemon=True)
+            t = threading.Thread(
+                target=self._watch_close,
+                args=(key, win, spec.on_closed),
+                daemon=True,
+            )
             t.start()
 
             return win

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@ GONet Wizard
    :alt: License
 
 A modular toolkit for handling, visualizing, and analyzing GONet camera data.  
-Includes an interactive Dash dashboard, CLI utilities, and tools for remote interaction with GONet devices.
+Includes a graphical launcher, image inspection, metadata review, region extraction, RAW-to-TIFF/JPEG conversion, an interactive Dash dashboard, and CLI utilities.
 
 📖 Documentation: https://gterreran.github.io/GONet_Wizard/
 
@@ -43,7 +43,8 @@ tools into your shell ``PATH``.
 **Python package for CLI users**
 
 If you want to run terminal commands such as ``GONet_Wizard show``,
-``GONet_Wizard extract``, or ``GONet_Wizard gui``, install the Python package:
+``GONet_Wizard extract``, ``GONet_Wizard split_raw``, or ``GONet_Wizard gui``,
+install the Python package:
 
 .. code-block:: bash
 

--- a/docs/source/api_reference/commands.rst
+++ b/docs/source/api_reference/commands.rst
@@ -74,6 +74,19 @@ Extract Command
    :members:
    :show-inheritance:
 
+Split RAW Command
+-----------------
+
+.. automodule:: GONet_Wizard.commands.split_raw
+   :members: COMMAND, output_paths_for_raw, split_raw_file, split_raw_files, cli_handler
+   :exclude-members: SplitRawOutput
+   :show-inheritance:
+
+   The ``SplitRawOutput`` helper is a small return container used internally by
+   the command implementation. The public API documentation focuses on the
+   command specification and conversion helpers because those are the stable
+   integration points.
+
 Show Metadata Command
 ---------------------
 

--- a/docs/source/cli_reference/index.rst
+++ b/docs/source/cli_reference/index.rst
@@ -63,6 +63,9 @@ Available Commands
    * - ``extract``
      - Extract pixel-count measurements from selected image regions.
      - :doc:`Extract GUI guide <../gui_guide/extract>`
+   * - ``split_raw``
+     - Convert original RAW GONet ``.jpg`` files into standard TIFF/JPEG products.
+     - :doc:`Split RAW Images GUI guide <../gui_guide/split_raw>`
    * - ``dashboard``
      - Launch the interactive dashboard from JSON or CSV data products.
      - :doc:`Dashboard GUI guide <../gui_guide/dashboard>`
@@ -116,6 +119,7 @@ Command Pages
    show
    show_meta
    extract
+   split_raw
    dashboard
    build_full_array
    gui
@@ -142,6 +146,9 @@ Most commands correspond directly to a user-facing tool page.
    * - ``extract``
      - :doc:`extraction tool guide <../tools/extract_measurements>`
      - Runs direct extraction or launches the interactive extraction app.
+   * - ``split_raw``
+     - :doc:`split RAW images tool guide <../tools/split_raw_images>`
+     - Converts RAW GONet ``.jpg`` files into standard TIFF/JPEG products.
    * - ``dashboard``
      - :doc:`dashboard tool guide <../tools/dashboard>`
      - Launches a Dash application from JSON/CSV products.

--- a/docs/source/cli_reference/split_raw.rst
+++ b/docs/source/cli_reference/split_raw.rst
@@ -1,0 +1,161 @@
+``split_raw``
+=============
+
+The ``split_raw`` command converts original GONet RAW ``.jpg`` files into
+standard image products that can be opened by ordinary image tools or reused in
+later GONet Wizard workflows.
+
+For the conceptual tool guide, see :doc:`split RAW images tool guide <../tools/split_raw_images>`.
+
+Usage
+-----
+
+.. code-block:: bash
+
+   GONet_Wizard split_raw [-h] [--outdir OUTDIR]
+                          [--format {both,tiff,jpeg}] [--overwrite]
+                          [--tiff-white-balance]
+                          [--no-jpeg-white-balance]
+                          input [input ...]
+
+Arguments
+---------
+
+``input``
+   One or more original GONet RAW ``.jpg`` files.
+
+   The command supports files, folders, wildcards, and comma-separated lists.
+   Inputs are filtered to ``.jpg`` files because this command is meant for the
+   original GONet RAW JPEG container, not for already converted ``.jpeg`` or
+   ``.tiff`` products.
+
+Output Products
+---------------
+
+By default, ``split_raw`` writes both products for each input file:
+
+* ``<stem>.tiff`` — a standard TIFF product.
+* ``<stem>.jpeg`` — a standard JPEG product.
+
+The converted JPEG uses the ``.jpeg`` extension intentionally. This avoids
+confusing the generated display JPEG with the original RAW ``.jpg`` container
+and prevents the default output name from overwriting the source file.
+
+When ``--outdir`` is omitted, products are written next to each input file.
+When ``--outdir`` is provided, GONet Wizard creates dedicated product folders:
+
+.. code-block:: text
+
+   OUTDIR/
+   ├── tiffs/
+   │   └── <stem>.tiff
+   └── jpegs/
+       └── <stem>.jpeg
+
+The product folders keep TIFF and JPEG outputs separated when converting many
+files at once.
+
+Options
+-------
+
+``--outdir OUTDIR``
+   Optional base output directory.
+
+   If omitted, outputs are written next to each input file. If supplied, TIFF
+   outputs are written under ``OUTDIR/tiffs`` and JPEG outputs are written under
+   ``OUTDIR/jpegs``. Missing output folders are created automatically.
+
+``--format {both,tiff,jpeg}``
+   Select which product type to write.
+
+   The default is ``both``. Use ``tiff`` when only scientific-style TIFF
+   products are needed, or ``jpeg`` when only visual products are needed.
+
+``--overwrite``
+   Allow existing output files to be replaced.
+
+   Without this flag, the command refuses to overwrite an existing output file.
+   This is deliberately conservative because batch conversions can produce many
+   files and accidental overwrites are otherwise easy to miss.
+
+``--tiff-white-balance``
+   Apply metadata white-balance gains to TIFF outputs.
+
+   TIFF white balance is disabled by default. The default keeps TIFF pixel
+   values as faithful as possible to the RAW data, which is usually preferable
+   when the TIFF may later be used for scientific extraction or quantitative
+   checks.
+
+``--no-jpeg-white-balance``
+   Disable metadata white-balance gains for JPEG outputs.
+
+   JPEG white balance is enabled by default because JPEG products are usually
+   created for visual inspection, quick review, sharing, or documentation.
+   Disable it only when you need the JPEG to reflect the unbalanced channel
+   scaling more directly.
+
+Examples
+--------
+
+Convert one RAW file to both products next to the input:
+
+.. code-block:: bash
+
+   GONet_Wizard split_raw image.jpg
+
+Convert all RAW files in a folder into a separate output directory:
+
+.. code-block:: bash
+
+   GONet_Wizard split_raw /path/to/raw_images --outdir /path/to/converted
+
+This creates products such as:
+
+.. code-block:: text
+
+   /path/to/converted/tiffs/image.tiff
+   /path/to/converted/jpegs/image.jpeg
+
+Write only TIFF products:
+
+.. code-block:: bash
+
+   GONet_Wizard split_raw *.jpg --format tiff --outdir converted
+
+Write only JPEG products:
+
+.. code-block:: bash
+
+   GONet_Wizard split_raw *.jpg --format jpeg --outdir converted
+
+Apply white balance to TIFF products:
+
+.. code-block:: bash
+
+   GONet_Wizard split_raw image.jpg --format tiff --tiff-white-balance
+
+Write JPEG products without white balance:
+
+.. code-block:: bash
+
+   GONet_Wizard split_raw image.jpg --format jpeg --no-jpeg-white-balance
+
+Replace existing converted outputs:
+
+.. code-block:: bash
+
+   GONet_Wizard split_raw *.jpg --outdir converted --overwrite
+
+GUI Equivalent
+--------------
+
+The graphical equivalent is :doc:`Split RAW Images GUI guide <../gui_guide/split_raw>`.
+
+Related Pages
+-------------
+
+* :doc:`split RAW images tool guide <../tools/split_raw_images>`
+* :doc:`GONet images user guide <../user_guide/gonet_images>`
+* :doc:`GONetFile user guide <../user_guide/gonetfile>`
+* :doc:`common CLI patterns <common_patterns>`
+* :doc:`commands API reference <../api_reference/commands>`

--- a/docs/source/developer_notes/command_system.rst
+++ b/docs/source/developer_notes/command_system.rst
@@ -36,6 +36,8 @@ The command system is implemented primarily in these files:
      - ``CommandSpec``, ``ParserSpec``
    * - ``GONet_Wizard/commands/__init__.py``
      - ``COMMANDS``, root ``PARSER``
+   * - ``GONet_Wizard/commands/split_raw.py``
+     - ``split_raw`` command declaration, output path handling, conversion orchestration
    * - ``GONet_Wizard/commands/parser_builder.py``
      - ``build_subparser()``, ``register_simple_subcommand()``
    * - ``GONet_Wizard/commands/ui_bridge.py``
@@ -222,6 +224,7 @@ Conceptually:
        extract,
        run_dashboard,
        build_full_array,
+       split_raw,
        gui,
    )
 
@@ -573,6 +576,28 @@ paths stored in the loaded extraction products.
 
 This is a good example of a command that launches an external interactive app
 through the shared UI runtime.
+
+``split_raw``
+~~~~~~~~~~~~~
+
+``commands/split_raw.py`` defines the ``split_raw`` command.
+
+Its ``COMMAND`` includes:
+
+* RAW GONet ``.jpg`` inputs,
+* an optional output directory,
+* product selection with ``--format``,
+* overwrite protection,
+* independent TIFF and JPEG white-balance flags.
+
+The handler filters inputs to original RAW ``.jpg`` files, resolves output paths,
+creates product subfolders when an output directory is supplied, and delegates
+image parsing/writing to ``GONetFile``. It prints a terminal summary and returns
+``None`` so the GUI form reports progress in its feedback terminal without
+opening a redundant result window.
+
+This is a good example of a file-writing command that is available from both the
+terminal and GUI forms while remaining non-interactive.
 
 ``gui``
 ~~~~~~~

--- a/docs/source/gui_guide/index.rst
+++ b/docs/source/gui_guide/index.rst
@@ -40,6 +40,9 @@ GUI Pages
    * - :doc:`Extract GUI guide <extract>`
      - Launch direct or interactive extraction from the GUI.
      - :doc:`extraction tool guide <../tools/extract_measurements>`
+   * - :doc:`Split RAW Images GUI guide <split_raw>`
+     - Convert RAW GONet ``.jpg`` files into standard TIFF/JPEG products.
+     - :doc:`split RAW images tool guide <../tools/split_raw_images>`
    * - :doc:`Dashboard GUI guide <dashboard>`
      - Launch the dashboard from a data directory.
      - :doc:`dashboard tool guide <../tools/dashboard>`
@@ -51,6 +54,7 @@ GUI Pages
    show
    show_meta
    extract
+   split_raw
    dashboard
 
 GUI Labels and CLI Commands
@@ -74,6 +78,9 @@ Each GUI page is a form-based frontend over a command-line command.
    * - :doc:`Extract GUI guide <extract>`
      - ``extract``
      - :doc:`extraction tool guide <../tools/extract_measurements>`
+   * - :doc:`Split RAW Images GUI guide <split_raw>`
+     - ``split_raw``
+     - :doc:`split RAW images tool guide <../tools/split_raw_images>`
    * - :doc:`Dashboard GUI guide <dashboard>`
      - ``dashboard``
      - :doc:`dashboard tool guide <../tools/dashboard>`

--- a/docs/source/gui_guide/launcher.rst
+++ b/docs/source/gui_guide/launcher.rst
@@ -17,6 +17,7 @@ The launcher provides access to the primary GONet Wizard tools:
 * Show Image
 * Show Metadata
 * Extract Region
+* Split RAW Images
 * Dashboard
 
 Each button opens a dedicated form used to configure and launch the
@@ -38,6 +39,7 @@ central access point to the underlying GONet Wizard command system.
    * :doc:`image inspection tool guide <../tools/inspect_images>`
    * :doc:`metadata inspection tool guide <../tools/inspect_metadata>`
    * :doc:`extraction tool guide <../tools/extract_measurements>`
+   * :doc:`split RAW images tool guide <../tools/split_raw_images>`
 
 Launcher Sections
 -----------------
@@ -69,6 +71,13 @@ user-defined regions of interest.
 
 See :doc:`Extract GUI guide <extract>`.
 
+**Split RAW Images**
+
+Launches the RAW splitting tool used to convert original GONet RAW ``.jpg``
+files into standard TIFF and JPEG products.
+
+See :doc:`Split RAW Images GUI guide <split_raw>`.
+
 Dashboard
 ~~~~~~~~~
 
@@ -87,6 +96,7 @@ Many users interact with GONet Wizard through a workflow similar to:
 #. Inspect images using **Show Image**.
 #. Review acquisition information using **Show Metadata**.
 #. Define measurement regions using **Extract Region**.
+#. Convert RAW files to TIFF/JPEG products with **Split RAW Images** when portable image outputs are needed.
 #. Analyze extracted products using the dashboard.
 
 Depending on the task, users may skip some of these steps or move directly to
@@ -103,6 +113,7 @@ GUI                CLI
 Show Image         ``show``
 Show Metadata      ``show_meta``
 Extract Region     ``extract``
+Split RAW Images   ``split_raw``
 Dashboard          ``dashboard``
 ================== ===================
 

--- a/docs/source/gui_guide/split_raw.rst
+++ b/docs/source/gui_guide/split_raw.rst
@@ -1,0 +1,175 @@
+Split RAW Images
+================
+
+The **Split RAW Images** form converts original GONet RAW ``.jpg`` files into
+standard TIFF and JPEG products from the graphical interface.
+
+.. note::
+
+   This page explains how to run RAW splitting from the GUI.
+
+   To learn what the tool does, when to use TIFF versus JPEG outputs, and why
+   the white-balance defaults differ, see :doc:`split RAW images tool guide <../tools/split_raw_images>`.
+
+Overview
+--------
+
+The Split RAW Images form is used to select one or more original GONet RAW
+``.jpg`` files, choose which converted products to write, and optionally choose a
+base output directory.
+
+The form is a graphical frontend for the ``split_raw`` command. The conversion
+runs directly from the form and reports progress in the command feedback
+terminal. It does not open a separate preview window because the command writes
+files and does not produce an interactive visualization.
+
+Selecting Files
+---------------
+
+The **RAW GONet JPG files or folders** field defines the input images.
+
+Files can be selected in two ways.
+
+Typing Paths
+~~~~~~~~~~~~
+
+Paths may be typed directly into the text field.
+
+The field supports:
+
+* Single file paths.
+* Folder paths.
+* Comma-separated entries.
+* Wildcards.
+
+This makes it possible to convert several files or groups of files without
+using the file browser.
+
+Browsing for Files
+~~~~~~~~~~~~~~~~~~
+
+The **Browse...** button opens a file picker.
+
+Multiple files may be selected at once. When the selection is confirmed, the
+selected paths are inserted into the input field automatically.
+
+Output Directory
+----------------
+
+The **Optional output directory** field controls where converted products are
+written.
+
+If this field is left blank, products are written next to each input file.
+
+If a directory is provided, GONet Wizard creates product-specific subfolders
+inside that directory:
+
+.. code-block:: text
+
+   selected-output-directory/
+   ├── tiffs/
+   └── jpegs/
+
+TIFF products are written to ``tiffs`` and JPEG products are written to
+``jpegs``. This keeps large batch conversions organized and makes it easier to
+use one product type in later workflows.
+
+Output Products
+---------------
+
+The **Output products** selector controls which files are created.
+
+Available choices are:
+
+* **TIFF and JPEG** — write both product types. This is the default.
+* **TIFF only** — write only ``.tiff`` products.
+* **JPEG only** — write only ``.jpeg`` products.
+
+TIFF products are the better default for scientific or quantitative follow-up.
+JPEG products are intended for visual inspection and sharing.
+
+White-Balance Controls
+----------------------
+
+The form exposes separate white-balance controls for TIFF and JPEG outputs.
+
+**Apply white balance to TIFF outputs**
+   Disabled by default.
+
+   TIFF outputs may be used later for scientific extraction or quantitative
+   checks. Leaving white balance off keeps pixel counts closer to the RAW data.
+
+**Disable white balance for JPEG outputs**
+   Disabled by default, meaning JPEG white balance is normally enabled.
+
+   JPEG outputs are usually display products, so white balance is enabled by
+   default to make them easier to inspect visually.
+
+Overwrite Existing Outputs
+--------------------------
+
+The **Overwrite existing outputs** checkbox controls whether existing converted
+files may be replaced.
+
+By default, GONet Wizard refuses to overwrite existing files. This protects
+previous conversions during batch runs. Enable overwrite only when you
+intentionally want to regenerate outputs.
+
+Running the Conversion
+----------------------
+
+To split RAW images from the GUI:
+
+#. Select one or more original GONet RAW ``.jpg`` files or folders.
+#. Optionally choose an output directory.
+#. Choose the output products.
+#. Adjust the white-balance checkboxes only if the defaults are not appropriate.
+#. Enable overwrite only if existing products should be replaced.
+#. Click **Split raw**.
+
+The command feedback terminal shows the command submitted by the form and the
+paths written by the conversion.
+
+Feedback Terminal
+-----------------
+
+The Split RAW Images form uses the same command feedback terminal pattern as
+other file-writing GUI commands.
+
+The terminal shows:
+
+* the command equivalent submitted by the form;
+* progress, warnings, and errors;
+* the input-to-output path summary after a successful conversion.
+
+Because ``split_raw`` writes files and does not create an interactive preview,
+no additional result window is opened after the command finishes.
+
+Navigation Buttons
+------------------
+
+The buttons at the bottom of the window control the GUI session.
+
+**Back to Main Menu**
+   Returns to the launcher without running the current form.
+
+**Exit**
+   Closes the graphical interface.
+
+Relationship to the CLI
+-----------------------
+
+The Split RAW Images form is the graphical frontend for the ``split_raw``
+command.
+
+Both interfaces use the same processing engine and produce the same TIFF/JPEG
+products.
+
+See Also
+--------
+
+* :doc:`split RAW images tool guide <../tools/split_raw_images>`
+* :doc:`split_raw CLI reference <../cli_reference/split_raw>`
+* :doc:`GONet images user guide <../user_guide/gonet_images>`
+* :doc:`GONetFile user guide <../user_guide/gonetfile>`
+* :doc:`GUI launcher guide <launcher>`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,8 +4,9 @@ GONet Wizard
 
 GONet Wizard is a command-line and graphical toolkit for working with GONet
 camera data. It includes utilities for inspecting GONet images, reading
-metadata, extracting measurements from regions of interest, building derived
-array products, and launching interactive GUI workflows.
+metadata, extracting measurements from regions of interest, converting RAW
+images into standard TIFF/JPEG products, building derived array products, and
+launching interactive GUI workflows.
 
 The documentation is organized by reader need. Start with the User Guide for
 concepts, the Tools section for task-oriented explanations, the GUI Guide or

--- a/docs/source/tools/index.rst
+++ b/docs/source/tools/index.rst
@@ -30,6 +30,10 @@ Tool Overview
      - Measure counts in user-defined image regions and save JSON/CSV products.
      - :doc:`Extract GUI guide <../gui_guide/extract>`
      - :doc:`extract CLI reference <../cli_reference/extract>`
+   * - :doc:`split RAW images tool guide <split_raw_images>`
+     - Convert original RAW GONet ``.jpg`` files into standard TIFF/JPEG products.
+     - :doc:`Split RAW Images GUI guide <../gui_guide/split_raw>`
+     - :doc:`split_raw CLI reference <../cli_reference/split_raw>`
    * - :doc:`dashboard tool guide <dashboard>`
      - Explore extracted JSON/CSV products in an interactive dashboard.
      - :doc:`Dashboard GUI guide <../gui_guide/dashboard>`
@@ -41,6 +45,7 @@ Tool Overview
    inspect_images
    inspect_metadata
    extract_measurements
+   split_raw_images
    dashboard
 
 Tool Names and Command Names
@@ -70,6 +75,10 @@ command name.
      - Extract
      - ``extract``
      - :doc:`extractor architecture developer notes <../developer_notes/extractor_architecture>`
+   * - :doc:`split RAW images tool guide <split_raw_images>`
+     - Split RAW Images
+     - ``split_raw``
+     - :doc:`command-system developer notes <../developer_notes/command_system>`
    * - :doc:`dashboard tool guide <dashboard>`
      - Dashboard
      - ``dashboard``

--- a/docs/source/tools/split_raw_images.rst
+++ b/docs/source/tools/split_raw_images.rst
@@ -1,0 +1,162 @@
+Split RAW Images
+================
+
+The split RAW images tool converts original GONet RAW ``.jpg`` files into
+standard TIFF and JPEG image products.
+
+This is useful because a GONet RAW ``.jpg`` file is not just an ordinary photo.
+It is a container that includes a display JPEG component, a packed RAW Bayer
+data block, and metadata. The split RAW workflow uses GONet Wizard's file parser
+to read the RAW content and write conventional image files that are easier to
+use outside the original container.
+
+Typical Uses
+------------
+
+Use this tool when you want to:
+
+* create standard TIFF files from original GONet RAW images;
+* create standard JPEG files for quick visual inspection or sharing;
+* prepare portable products for tools that do not understand the GONet RAW JPEG
+  container;
+* separate scientific-style products from display-oriented products;
+* batch-convert folders of RAW GONet images.
+
+Supported Inputs
+----------------
+
+The tool accepts original GONet RAW ``.jpg`` files.
+
+Although the output JPEG products use the ``.jpeg`` extension, those converted
+``.jpeg`` files are not valid inputs to ``split_raw``. They are standard display
+products, not RAW GONet containers. Already converted ``.tiff`` files are also
+not inputs to this command.
+
+Output Products
+---------------
+
+The tool can write two product types.
+
+TIFF Products
+~~~~~~~~~~~~~
+
+TIFF products are intended to preserve more of the sensor-level information
+available from the RAW data.
+
+By default, TIFF outputs are written without white balance. This default is
+intentional: if the TIFF may later be used for scientific extraction,
+calibration checks, or quantitative comparisons, the safest behavior is to keep
+pixel counts as close as possible to the original RAW data rather than applying
+visual channel gains.
+
+Use TIFF products when the output may remain part of a measurement workflow.
+
+JPEG Products
+~~~~~~~~~~~~~
+
+JPEG products are standard 8-bit display images.
+
+By default, JPEG outputs are written with white balance enabled. This default is
+also intentional: JPEGs are usually used for visual inspection, documentation,
+sharing, or quick quality checks, where a visually interpretable color balance is
+more useful than raw-like channel scaling.
+
+Use JPEG products when the output is meant to be viewed rather than measured.
+
+White-Balance Defaults
+----------------------
+
+The TIFF and JPEG defaults are different because the two products serve
+different purposes.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 25 55
+
+   * - Product
+     - Default white balance
+     - Reason
+   * - TIFF
+     - Off
+     - Preserve raw-like pixel counts for scientific extraction and quantitative workflows.
+   * - JPEG
+     - On
+     - Produce visually useful images for inspection, sharing, and documentation.
+
+Both defaults can be changed. The CLI exposes ``--tiff-white-balance`` and
+``--no-jpeg-white-balance``. The GUI exposes matching checkbox controls.
+
+Output Organization
+-------------------
+
+When no output directory is supplied, converted products are written next to the
+input file:
+
+.. code-block:: text
+
+   image.jpg
+   image.tiff
+   image.jpeg
+
+When an output directory is supplied, the tool creates dedicated product
+subfolders:
+
+.. code-block:: text
+
+   converted/
+   ├── tiffs/
+   │   └── image.tiff
+   └── jpegs/
+       └── image.jpeg
+
+The subfolder layout keeps mixed product types organized during batch
+conversion. It also makes it easier to pass only TIFFs or only JPEGs to a later
+workflow.
+
+Overwrite Safety
+----------------
+
+The split RAW workflow does not overwrite existing products by default.
+
+This conservative behavior is useful during batch processing because a command
+may generate many outputs at once. Refusing existing output paths helps prevent
+accidental replacement of earlier conversions. Use the overwrite option only
+when you intentionally want to regenerate products.
+
+Accessing the Tool
+------------------
+
+The split RAW images tool can be accessed through both the graphical user
+interface and the command-line interface.
+
+See:
+
+* :doc:`Split RAW Images GUI guide <../gui_guide/split_raw>`
+* :doc:`split_raw CLI reference <../cli_reference/split_raw>`
+
+Where to Go Next
+----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 35 65
+
+   * - Need
+     - Page
+   * - Launch conversion from the GUI
+     - :doc:`Split RAW Images GUI guide <../gui_guide/split_raw>`
+   * - Run conversion from the terminal
+     - :doc:`split_raw CLI reference <../cli_reference/split_raw>`
+   * - Understand GONet RAW image containers
+     - :doc:`GONet images user guide <../user_guide/gonet_images>`
+   * - Understand the file object used by the converter
+     - :doc:`GONetFile user guide <../user_guide/gonetfile>`
+   * - Review the command implementation API
+     - :doc:`commands API reference <../api_reference/commands>`
+
+Related Topics
+--------------
+
+* :doc:`image inspection tool guide <inspect_images>`
+* :doc:`extraction tool guide <extract_measurements>`
+* :doc:`channels user guide <../user_guide/channels>`

--- a/docs/source/user_guide/gonet_images.rst
+++ b/docs/source/user_guide/gonet_images.rst
@@ -32,7 +32,10 @@ The JPEG component is the image that ordinary viewers open. It is useful for:
 - checking framing, clouds, gross image quality, or obvious acquisition issues.
 
 Because the JPEG is processed and compressed, it should not be treated as the
-most reliable source for quantitative sensor-level measurements.
+most reliable source for quantitative sensor-level measurements. When a
+standard display-oriented JPEG product is needed outside the original GONet RAW
+container, use the :doc:`split RAW images tool <../tools/split_raw_images>` to
+write a converted ``.jpeg`` file.
 
 Raw Bayer component
 -------------------
@@ -44,7 +47,8 @@ split into channels.
 
 GONet Wizard parses this raw block and exposes the resulting data through
 channel arrays. Those arrays are the basis for channel display, full-array
-construction, and extraction workflows.
+construction, extraction workflows, and conversion to standard TIFF/JPEG
+products through the :doc:`split RAW images tool <../tools/split_raw_images>`.
 
 Metadata
 --------
@@ -60,6 +64,25 @@ context, this can include information such as:
 
 The exact available fields may vary between files. GONet Wizard therefore uses a
 structured metadata model rather than assuming every file contains every field.
+
+Converted TIFF and JPEG products
+--------------------------------
+
+Original GONet RAW files normally use the ``.jpg`` extension because the file
+contains a JPEG component. Converted products should be treated differently:
+
+``.tiff``
+    A standard TIFF image written from the parsed RAW data. GONet Wizard keeps
+    TIFF white balance disabled by default in the split RAW workflow so the
+    output remains better suited to quantitative follow-up.
+
+``.jpeg``
+    A standard JPEG image written for display. GONet Wizard uses the ``.jpeg``
+    extension for converted JPEGs to distinguish them from the original RAW
+    ``.jpg`` containers. JPEG white balance is enabled by default because these
+    products are usually intended for visual inspection.
+
+For conversion instructions, see :doc:`split RAW images tool guide <../tools/split_raw_images>`.
 
 How GONet Wizard reads image files
 ----------------------------------
@@ -79,5 +102,6 @@ Where to Go Next
 * :doc:`GONetFile user guide <gonetfile>`
 * :doc:`channels user guide <channels>`
 * :doc:`metadata inspection tool guide <../tools/inspect_metadata>`
+* :doc:`split RAW images tool guide <../tools/split_raw_images>`
 * :doc:`GONetFile API reference <../api_reference/gonet>`
 

--- a/docs/source/user_guide/gonetfile.rst
+++ b/docs/source/user_guide/gonetfile.rst
@@ -23,7 +23,8 @@ A GONet image file can contain several kinds of information:
 
 Rather than passing these pieces around separately, GONet Wizard loads them into
 a structured object. This gives the rest of the package a consistent way to ask
-for channels, metadata, filenames, and output representations.
+for channels, metadata, filenames, and output representations, including the
+standard TIFF and JPEG products written by the ``split_raw`` command.
 
 Conceptual structure
 --------------------
@@ -125,9 +126,9 @@ Relationship to commands and the GUI
 ------------------------------------
 
 Both the CLI and the GUI ultimately operate on GONet file objects. For example,
-when the user asks GONet Wizard to show an image, inspect metadata, or extract
-measurements, the input file is first normalized into one of these internal
-representations.
+when the user asks GONet Wizard to show an image, inspect metadata, extract
+measurements, or split a RAW ``.jpg`` into standard image products, the input
+file is first normalized into one of these internal representations.
 
 This design is one of the reasons the GUI and CLI can share the same processing
 engine: they both work with the same internal model of a GONet image.
@@ -137,5 +138,6 @@ Where to Go Next
 
 * :doc:`GONetFile API reference <../api_reference/gonet>`
 * :doc:`GONet parsers and writers API reference <../api_reference/gonet_parsers_writers>`
+* :doc:`split RAW images tool guide <../tools/split_raw_images>`
 * :doc:`command-system developer notes <../developer_notes/command_system>`
 

--- a/tests/test_extract_window_lifecycle.py
+++ b/tests/test_extract_window_lifecycle.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import threading
+
+from GONet_Wizard.GONet_utils.src.extract_app.extract_gui import (
+    _configure_extract_gui,
+    cancel_interactive_extraction_if_unsubmitted,
+    mark_interactive_extraction_submitted,
+    app as extract_app,
+)
+from GONet_Wizard.ui.windows import WindowManager
+
+
+class DummyTerminalStream:
+    def __init__(self) -> None:
+        self.calls = []
+        self._done = False
+
+    @property
+    def is_done(self) -> bool:
+        return self._done
+
+    def finish(self, **kwargs) -> None:
+        self.calls.append(kwargs)
+        self._done = True
+
+
+def test_cancel_unsubmitted_interactive_extraction_finishes_stream() -> None:
+    terminal_stream = DummyTerminalStream()
+    _configure_extract_gui(["image.jpg"], terminal_stream=terminal_stream)
+
+    cancel_interactive_extraction_if_unsubmitted()
+
+    assert terminal_stream.calls == [
+        {
+            "status": "error",
+            "message": "Interactive extraction cancelled before output was written.",
+        }
+    ]
+    assert extract_app.server.config.get("terminal_stream") is None
+
+
+def test_cancel_unsubmitted_interactive_extraction_does_not_finish_after_submit() -> None:
+    terminal_stream = DummyTerminalStream()
+    _configure_extract_gui(["image.jpg"], terminal_stream=terminal_stream)
+    mark_interactive_extraction_submitted()
+
+    cancel_interactive_extraction_if_unsubmitted()
+
+    assert terminal_stream.calls == []
+    assert extract_app.server.config.get("terminal_stream") is terminal_stream
+
+
+def test_window_close_watcher_invokes_on_closed_callback() -> None:
+    manager = WindowManager()
+    closed_event = threading.Event()
+
+    class DummyEvents:
+        closed = closed_event
+
+    class DummyWindow:
+        events = DummyEvents()
+
+    win = DummyWindow()
+    calls = []
+    manager._windows["extract-gui"] = win
+    closed_event.set()
+
+    manager._watch_close("extract-gui", win, lambda: calls.append("closed"))
+
+    assert manager.get("extract-gui") is None
+    assert calls == ["closed"]

--- a/tests/test_gui_form_page.py
+++ b/tests/test_gui_form_page.py
@@ -82,3 +82,23 @@ def test_preview_shell_proxies_save_dialog_requests_to_pywebview():
     assert "pick_save_path" in html
     assert "sourceWindow.postMessage" in html
     assert html.count("gonet-close-window") == 1
+
+
+def test_split_raw_page_uses_terminal_and_lists_options():
+    app = _template_app()
+
+    with app.test_client() as client:
+        response = client.get("/cmd/split_raw")
+
+    html = response.get_data(as_text=True)
+
+    assert response.status_code == 200
+    assert 'id="command-terminal"' in html
+    assert 'id="terminal-output"' in html
+    assert 'name="input"' in html
+    assert 'name="outdir"' in html
+    assert 'name="format"' in html
+    assert 'name="overwrite"' in html
+    assert 'name="tiff_white_balance"' in html
+    assert 'name="no_jpeg_white_balance"' in html
+    assert 'id="output"' not in html

--- a/tests/test_split_raw_command.py
+++ b/tests/test_split_raw_command.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import GONet_Wizard.commands.split_raw as split_raw
+
+
+class FakeGONetFile:
+    loaded: list[Path] = []
+    written_tiffs: list[tuple[str, bool]] = []
+    written_jpegs: list[tuple[str, bool]] = []
+
+    @classmethod
+    def reset(cls) -> None:
+        cls.loaded = []
+        cls.written_tiffs = []
+        cls.written_jpegs = []
+
+    @classmethod
+    def from_file(cls, path):
+        cls.loaded.append(Path(path))
+        return cls()
+
+    def write_to_tiff(self, path, white_balance=True):
+        self.written_tiffs.append((str(path), white_balance))
+        Path(path).write_text("tiff")
+
+    def write_to_jpeg(self, path, white_balance=True):
+        self.written_jpegs.append((str(path), white_balance))
+        Path(path).write_text("jpeg")
+
+
+@pytest.fixture(autouse=True)
+def fake_gonet_file(monkeypatch):
+    FakeGONetFile.reset()
+    monkeypatch.setattr(split_raw, "GONetFile", FakeGONetFile)
+    return FakeGONetFile
+
+
+def test_output_paths_default_next_to_input_with_safe_jpeg_suffix(tmp_path: Path):
+    raw = tmp_path / "image.jpg"
+
+    paths = split_raw.output_paths_for_raw(raw)
+
+    assert paths.input_file == raw
+    assert paths.tiff == tmp_path / "image.tiff"
+    assert paths.jpeg == tmp_path / "image.jpeg"
+
+
+def test_split_raw_file_writes_tiff_and_jpeg_by_default(tmp_path: Path):
+    raw = tmp_path / "image.jpg"
+    raw.write_text("raw")
+
+    outputs = split_raw.split_raw_file(raw)
+
+    assert outputs.tiff == tmp_path / "image.tiff"
+    assert outputs.jpeg == tmp_path / "image.jpeg"
+    assert FakeGONetFile.loaded == [raw]
+    assert FakeGONetFile.written_tiffs == [(str(tmp_path / "image.tiff"), False)]
+    assert FakeGONetFile.written_jpegs == [(str(tmp_path / "image.jpeg"), True)]
+
+
+def test_output_paths_use_product_subfolders_when_outdir_is_set(tmp_path: Path):
+    raw = tmp_path / "image.jpg"
+    outdir = tmp_path / "converted"
+
+    paths = split_raw.output_paths_for_raw(raw, outdir=outdir)
+
+    assert paths.tiff == outdir / "tiffs" / "image.tiff"
+    assert paths.jpeg == outdir / "jpegs" / "image.jpeg"
+
+
+def test_split_raw_file_can_apply_tiff_white_balance(tmp_path: Path):
+    raw = tmp_path / "image.jpg"
+    raw.write_text("raw")
+
+    split_raw.split_raw_file(raw, output_format="tiff", tiff_white_balance=True)
+
+    assert FakeGONetFile.written_tiffs == [(str(tmp_path / "image.tiff"), True)]
+    assert FakeGONetFile.written_jpegs == []
+
+
+def test_split_raw_file_can_write_only_jpeg_without_white_balance(tmp_path: Path):
+    raw = tmp_path / "image.jpg"
+    raw.write_text("raw")
+    outdir = tmp_path / "converted"
+
+    outputs = split_raw.split_raw_file(
+        raw,
+        outdir=outdir,
+        output_format="jpeg",
+        jpeg_white_balance=False,
+    )
+
+    assert outputs.tiff is None
+    assert outputs.jpeg == outdir / "jpegs" / "image.jpeg"
+    assert FakeGONetFile.written_tiffs == []
+    assert FakeGONetFile.written_jpegs == [(str(outdir / "jpegs" / "image.jpeg"), False)]
+
+
+def test_split_raw_file_refuses_existing_output_without_overwrite(tmp_path: Path):
+    raw = tmp_path / "image.jpg"
+    raw.write_text("raw")
+    (tmp_path / "image.tiff").write_text("old")
+
+    with pytest.raises(FileExistsError, match="Use --overwrite"):
+        split_raw.split_raw_file(raw)
+
+    assert FakeGONetFile.loaded == []
+
+
+def test_cli_handler_filters_inputs_and_passes_options(monkeypatch, tmp_path: Path, capsys):
+    raw = tmp_path / "image.jpg"
+    raw.write_text("raw")
+    ignored = tmp_path / "notes.txt"
+    ignored.write_text("ignore")
+    calls = []
+
+    def fake_split_raw_files(**kwargs):
+        calls.append(kwargs)
+        return [
+            split_raw.SplitRawOutput(
+                input_file=raw,
+                tiff=None,
+                jpeg=tmp_path / "out" / "jpegs" / "image.jpeg",
+            )
+        ]
+
+    monkeypatch.setattr(split_raw, "split_raw_files", fake_split_raw_files)
+
+    args = SimpleNamespace(
+        input=[raw, ignored],
+        outdir=str(tmp_path / "out"),
+        format="jpeg",
+        overwrite=True,
+        tiff_white_balance=True,
+        no_jpeg_white_balance=True,
+    )
+
+    summary = split_raw.cli_handler(args)
+    captured = capsys.readouterr()
+
+    assert calls == [
+        {
+            "input_files": [raw],
+            "outdir": str(tmp_path / "out"),
+            "output_format": "jpeg",
+            "overwrite": True,
+            "tiff_white_balance": True,
+            "jpeg_white_balance": False,
+        }
+    ]
+    assert summary is None
+    assert str(tmp_path / "out" / "jpegs" / "image.jpeg") in captured.out


### PR DESCRIPTION
## Summary

Adds a new `split_raw` command for converting GONet RAW JPG images into science-preserving TIFF files and presentation-ready JPEG files.

## Changes

- Added the `split_raw` CLI command.
- Added a GUI form for `split_raw`.
- Writes outputs into dedicated `tiffs/` and `jpegs/` subfolders under `--outdir`.
- Defaults TIFF white balance to off to preserve raw pixel counts for scientific extraction.
- Defaults JPEG white balance to on for visually useful preview/output images.
- Added independent white-balance flags for TIFF and JPEG outputs.
- Prevented redundant result-window creation when running from the GUI.
- Added tests for output path generation, overwrite handling, CLI behavior, and GUI rendering.
- Added CLI, GUI, tools, API, README, and user/developer documentation.
- Cleaned Sphinx warnings from the new API docs.

## Validation

- `pytest`
- `sphinx-build -b html docs/source docs/build/html`